### PR TITLE
Ptolemy's theorem as proved formally by Tuan-Minh Pham in 2009

### DIFF
--- a/Ptolemee.v
+++ b/Ptolemee.v
@@ -1,0 +1,420 @@
+
+Require Export triangles_semblables.
+Require Export orientation.
+
+
+(***********************************************************************)
+                              (*Main proof of Ptoleme *)
+(***********************************************************************)
+Lemma EntreDeuxVec_sym :
+forall (A B C M N :PO),
+         vecEntreDeuxVec A B C M -> A<>N->
+         cons_AV ( vec A B) (vec A M) = cons_AV (vec A N) (vec A C) ->
+         vecEntreDeuxVec A B C N.
+intros A B C M N H H0 H1.
+unfold vecEntreDeuxVec in *.
+assert (H2: A<>B /\ A<>C /\ A<>M).
+elim H;intros [H3[H4 H5]];
+    deroule_orient H3;deroule_orient H5;repeat split;auto.
+destruct H2 as [H2 [H3 H4]].
+assert (H5: cons_AV (vec A B)(vec A N) = cons_AV (vec A M) (vec A C)).
+rewrite <-(@Chasles A B A M A N);auto.
+rewrite H1.
+rewrite plus_commutative.
+rewrite ->(@Chasles A M A N A C);auto.
+elim H;intros [H6[H7 H8]].
+left.
+split;auto.
+split;auto.
+apply (@anglesEgaux_orient A M C);auto.
+apply (@anglesEgaux_orient A B M);auto.
+right.
+split;auto.
+split;auto.
+apply (@anglesEgaux_orient A M B);auto.
+apply permute_angles;auto.
+apply (@anglesEgaux_orient A C M);auto .
+apply permute_angles;auto.
+Qed.
+
+Lemma EntreDeuxPoint :
+forall ( A B M :PO),
+          positifColineaire A B M -> positifColineaire B A M -> distance A B = distance A M + distance M B.
+intros A B M H0 H1.
+destruct H0 as [k [H2 [H3 H4]]].
+destruct H1 as [k' [H5 [H6 H7]]].
+assert (vec M B  = mult_PP k' (vec A B)).
+rewrite (@opp_vecteur B A).
+rewrite ->mult_mult_vec.
+rewrite (@opp_vecteur B M).
+rewrite H6.
+rewrite ->mult_mult_vec.
+replace (-1 * k') with (k' *-1);auto.
+ring.
+assert (H8: vec A B = add_PP (vec A M)(vec M B)).
+symmetry.
+apply (@Chasles_vec A M B) ;auto.
+rewrite H3 in H8.
+rewrite H in H8.
+replace ( add_PP(mult_PP k(vec A B)) (mult_PP k' (vec A B)))
+             with (mult_PP (k+k')(vec A B)) in H8;[idtac|RingPP].
+assert (H9: add_PP (mult_PP (k+k') (vec A B)) (mult_PP (-1) (vec A B)) = zero).
+rewrite <-H8.
+rewrite <-opp_vecteur.
+rewrite Chasles_vec.
+unfold vec.
+rewrite add_PP_A.
+replace (-1+1) with 0.
+rewrite<-def_zero;auto.
+ring.
+replace ( add_PP(mult_PP (k+k') (vec A B)) (mult_PP (-1) (vec A B)))
+             with (mult_PP (k+k'+-1)(vec A B)) in H9;[idtac|RingPP].
+elim (@produit_vecteur_nul (k+k'+-1) A B H9);intros H10.
+assert ( H11 : distance A M = Rabs k *distance A B)
+  by (apply (@colinearite_distance k A B A M H3)) .
+assert ( H12 : distance M B = Rabs k' *distance A B)
+  by (apply (@colinearite_distance k' A B M B H)) .
+rewrite Rabs_right in H11;[idtac|lra].
+rewrite Rabs_right in H12;[idtac|lra].
+rewrite H11.
+rewrite H12.
+rewrite<-Rmult_plus_distr_r.
+assert (k+k' =1).
+auto with *.
+rewrite H0; ring.
+elim H2;auto.
+Qed.
+
+Require Export Droite_espace.
+
+
+Lemma Exists_Intersection1 : (* on peut prouver grace au lemme
+droites_non_paralleles *)
+forall (A B C D :PO),
+          vecEntreDeuxVec A B C D ->
+          exists E :PO, alignes A D E /\ alignes B C E.
+intros A B C D H.
+assert (H0 : ~alignes A D B /\ A <>D)
+ by(destruct H as [[_ [H2 _]]|[_ [_ H2]]];deroule_orient H2;auto with geo).
+destruct H0 as [H0 H1].
+assert (H2 : ~alignes A D C)
+ by(destruct H as [[_ [_ H3 ]]|[_ [H3 _]]];deroule_orient H3;auto with geo).
+assert (H3 : B<>C)
+ by(destruct H as [[H4 [_ _]]|[H4 [_ _]]];deroule_orient H4;auto with geo).
+destruct (@existence_pt_intersection A D B C ) as [E H4];auto.
+assert (H4: ~ paralleles (droite A D) (droite B C)).
+red;intros H4.
+destruct (@existence_representant_vecteur A B C) as [D' H5].
+destruct (@paralleles_vecteur A D B C ) as [k H6];auto.
+destruct H as [[H7 [H8 H9]]|[H7 [H8 H9]]].
+assert (aire(vec B C)(vec A D) = 0) by (apply aire_colinearite with (k:=k) ;auto).
+rewrite <-(@Chasles_vec B A C) in H.
+rewrite aire_distrib_r in H.
+assert (aire (vec B A)(vec A D) <0).
+VReplace (vec B A) (mult_PP (-1) (vec A B)).
+rewrite aire_colineaire_l.
+unfold orient in H8;lra.
+assert (aire (vec A C)(vec A D) <0).
+rewrite aire_anti_symetrique.
+unfold orient in H9;lra.
+lra.
+assert (aire(vec B C)(vec A D) = 0) by (apply aire_colinearite with (k:=k) ;auto).
+rewrite <-(@Chasles_vec B A C) in H.
+rewrite aire_distrib_r in H.
+assert (aire (vec B A)(vec A D) >0).
+VReplace (vec B A) (mult_PP (-1) (vec A B)).
+rewrite aire_colineaire_l.
+rewrite aire_anti_symetrique.
+unfold orient in H9.
+replace (-1) with (-(1)) by ring.
+rewrite Ropp_mult_distr_l_reverse.
+rewrite Ropp_mult_distr_r_reverse.
+lra.
+assert (aire (vec A C)(vec A D) >0).
+unfold orient in H8;auto.
+lra.
+elim (@droites_non_paralleles  B C A D H3 H1 H4);auto.
+intros H5.
+(*here we use an axiom of plane geometry,
+which one to say that every 4 points are COPLANAR   *)
+assert (H6: coplanaires B C A D) by apply geometrie_plane.
+elim H5;auto.
+exists E;auto.
+apply def_pt_intersection2;auto.
+Qed.
+
+
+Lemma  angles_representants_unitaires_r :
+(*consequence de l'axiom angles_representants_unitaires *)
+    forall A B C D E F : PO,
+    A <> B ->
+    C <> D ->
+    cons_AV (vec A B) (vec C D) =
+    cons_AV  (vec A B)
+      (representant_unitaire (vec C D)).
+intros A B C D E F H H0.
+assert (H1: cons_AV (vec A B)(vec C D) =
+    cons_AV (representant_unitaire (vec A B))(representant_unitaire(vec C D))).
+apply angles_representants_unitaires ;auto.
+rewrite H1.
+destruct (@existence_representant_unitaire A B H) as [B' H2].
+assert (H3 : exists k:R, k>0 /\
+                                      vec A B = mult_PP k (vec A B')).
+apply (@egalite_representant_unitaire A B' B);auto.
+destruct (@def_representant_unitaire2 A B B' H H2) as  [_ [H3 _]].
+apply unitaire_distincts ;auto.
+rewrite H2;apply representant_unitaire_bis;auto.
+destruct H3 as [k[H3 H4]].
+rewrite <-H2.
+destruct (@existence_representant_unitaire C D H0) as [D' H5].
+rewrite <-H5.
+rewrite H4.
+symmetry.
+apply  angle_produit_positif_l;auto.
+destruct (@def_representant_unitaire2 A B B' H H2) as  [_ [H6 _]].
+apply unitaire_distincts ;auto.
+destruct (@def_representant_unitaire2 C D D' H0 H5) as  [_ [H6 _]].
+apply unitaire_distincts ;auto.
+Qed.
+
+Lemma  angles_representants_unitaires2 :
+(*consequence de l'axiom angles_representants_unitaires *)
+    forall A B C D E F : PO,
+    A <> B ->
+    C <> D ->
+    cons_AV (vec A B) (vec C D) =
+    cons_AV (representant_unitaire (vec A B)) (vec C D).
+intros A B C D E F H H0.
+assert (H1: cons_AV (vec A B)(vec C D) =
+    cons_AV (representant_unitaire (vec A B))(representant_unitaire(vec C D))).
+apply angles_representants_unitaires ;auto.
+rewrite H1.
+destruct (@existence_representant_unitaire C D H0) as [D' H2].
+assert (H3 : exists k:R, k>0 /\
+                                      vec C D = mult_PP k (vec C D')).
+apply (@egalite_representant_unitaire C D' D);auto.
+destruct (@def_representant_unitaire2 C D D' H0 H2) as  [_ [H3 _]].
+apply unitaire_distincts ;auto.
+rewrite H2;apply representant_unitaire_bis;auto.
+destruct H3 as [k[H3 H4]].
+rewrite <-H2.
+destruct (@existence_representant_unitaire A B H) as [B' H5].
+rewrite <-H5.
+rewrite H4.
+symmetry.
+apply  angle_produit_positif_r2;auto.
+destruct (@def_representant_unitaire2 C D D' H0 H2) as  [_ [H6 _]].
+apply unitaire_distincts ;auto.
+destruct (@def_representant_unitaire2 A B B' H H5) as  [_ [H6 _]].
+apply unitaire_distincts ;auto.
+Qed.
+
+
+Lemma Exists_Intersection :
+forall (A B C D :PO),
+          vecEntreDeuxVec A B C D ->
+          exists E :PO, cons_AV ( vec A B) (vec A E) = cons_AV (vec A D) (vec A C)
+                               /\  positifColineaire B C E /\ positifColineaire C B E.
+intros A B C D H.
+assert (H1: A<>B /\ A<>C /\ A<>D).
+elim H;intros [H2[H3 H4]];
+    deroule_orient H2;deroule_orient H4;repeat split;auto.
+destruct H1 as [H1 [H2 H3]].
+destruct (@existence_representant_unitaire A B) as [B' H4];auto.
+destruct(@existence_representant_cons (cons_AV (vec A D)(vec A C)) A B' A) as [E' [H5 H6]].
+unfold distance.
+destruct (@def_representant_unitaire2 A B B' H1 H4) as [_ [H7 _]].
+rewrite H7.
+rewrite sqrt_1;auto.
+assert (H7: A<>E').
+red;intros.
+rewrite H0 in H5.
+assert (distance E' E' =0) by (apply distance_refl2;auto).
+rewrite H7 in H5.
+(*info auto with real.*)
+assert (1<>0) by lra.
+elim H8;auto.
+assert (H8 : cons_AV (vec A B)(vec A E') = cons_AV (vec A B') (vec A E')).
+rewrite H4.
+apply angles_representants_unitaires2;auto.
+rewrite <-H8 in H6.
+assert (H9 :cons_AV (vec A E')(vec A C) = cons_AV (vec A B)(vec A D)).
+rewrite <-(@Chasles A B A E' A D);auto.
+rewrite <-H6.
+rewrite plus_commutative.
+rewrite ->(@Chasles A E' A D A C);auto.
+assert (H10:vecEntreDeuxVec A B C E').
+apply (@EntreDeuxVec_sym A B C D E');auto.
+destruct (@Exists_Intersection1 A B C E') as [E [H11 H12]];auto.
+exists E.
+destruct (@vecEntreDeuxVec_intersection_middle A B C E'  H10 E ) as [H13 [H14 H15]];auto.
+repeat split;auto.
+destruct H15 as [k [H16[H17 H18]]].
+rewrite (@angle_produit_positif_r k A E' E A B);auto.
+Qed.
+
+Ltac deroule_sont_cocycliques :=
+  match goal with H : sont_cocycliques ?A ?B ?C ?D|- _ =>
+  generalize H ; let name := fresh in intros name  ;
+  unfold sont_cocycliques in name;
+  destruct name ;decompose [and] name; clear name;
+ repeat match goal with H' : circonscrit ?O ?A ?B ?C  |- _ =>
+  unfold circonscrit  in H';
+  decompose [and] H' ; clear H' end ;
+ repeat match goal with H' : isocele ?O ?A ?B  |- _ =>
+  unfold isocele  in H'
+  end
+end.
+
+Lemma sont_cocycliques_avec_ordre_cycle:
+forall (A B C D :PO),
+         sont_cocycliques A B C D ->sont_cocycliques B C D A.
+intros A B C D H.
+deroule_sont_cocycliques .
+unfold sont_cocycliques .
+exists x.
+unfold circonscrit in *.
+unfold isocele in *.
+repeat split ;auto.
+rewrite H4 in H2;auto.
+rewrite H3 in H0;auto.
+rewrite H4 in H2;auto.
+Qed.
+
+Lemma sont_cocycliques_avec_ordre_permute:
+forall (A B C D :PO),
+         sont_cocycliques A B C D ->sont_cocycliques A B D C.
+intros A B C D H.
+deroule_sont_cocycliques .
+unfold sont_cocycliques .
+exists x.
+unfold circonscrit in *.
+unfold isocele in *.
+repeat split ;auto.
+Qed.
+
+
+Theorem Ptolemee:
+forall (A B C D : PO),
+         orient A B C -> orient A B D -> orient C D A -> orient C D B ->
+         sont_cocycliques A B C D ->
+         (distance A B  * distance C D ) + (distance B C *distance D A) =
+              distance A C  * distance B D .
+intros A B C D H0 H1 H2 H3 H4.
+assert ( H5: A<>B /\ A<>C /\ ~alignes A B C).
+deroule_orient H0;repeat split;auto.
+destruct H5 as [H5 [H6 H7]].
+assert ( H8: A<>B /\ A<>D /\ ~alignes A B D).
+deroule_orient H1;repeat split;auto.
+destruct H8 as [H8 [H9 H10]].
+assert ( H11: C<>D /\ C<>A /\ ~alignes C D A).
+deroule_orient H2;repeat split;auto.
+destruct H11 as [H11 [H12 H13]].
+assert ( H14: C<>D /\ C<>B /\ ~alignes C D B).
+deroule_orient H3;repeat split;auto.
+destruct H14 as [H14 [H15 H16]].
+destruct (@Exists_Intersection C D B A) as [E [H17 [H18 H19]]].
+unfold vecEntreDeuxVec.
+left.
+split;auto.
+split;auto.
+apply orient_cycle;apply orient_cycle;auto.
+assert (H20 : E<>C).
+red;intro.
+rewrite H in H18.
+destruct H18 as [k [_ [H20 _]]].
+assert (alignes D B C) by (apply (@colineaire_alignes k);auto).
+assert (alignes C D B) by (apply alignes_ordre_cycle2 ;auto).
+elim H16;auto.
+assert (H21 : cons_AV (vec C E) (vec C B) = cons_AV (vec C D) (vec C A)).
+rewrite <-(@Chasles C E C A C B);auto.
+rewrite <-H17.
+rewrite (plus_commutative).
+rewrite Chasles ;auto.
+
+assert (H40 : E<>D).
+red;intros.
+rewrite H in H17.
+rewrite <-angle_nul in H17; auto.
+destruct (@angle_nul_positif_colineaire C A B ) as [k [H41 H42]];auto.
+assert (alignes C A B ) by (apply (@colineaire_alignes k);auto).
+assert (alignes A B C) by (apply alignes_ordre_cycle ;auto).
+elim H7;auto.
+assert (H41 : E<>B).
+red;intros.
+rewrite H in H21.
+rewrite <-angle_nul in H21; auto.
+destruct (@angle_nul_positif_colineaire C D A ) as [k [H41 H42]];auto.
+assert (alignes C D A ) by (apply (@colineaire_alignes k);auto).
+elim H13;auto.
+
+
+assert (H22 : cons_AV (vec D E) (vec D C) = cons_AV (vec A B )(vec A C)).
+destruct H18 as [k [H22 [H23 H24]]].
+rewrite H23.
+rewrite (@angle_produit_positif_l k D B D C);auto.
+apply consAD_orient_consAV;auto.
+apply cocyclicite;auto with geo.
+apply sont_cocycliques_avec_ordre_cycle;auto.
+apply orient_cycle;auto.
+
+
+assert (H23:cons_AV (vec A C) (vec A D) = cons_AV (vec B C )(vec B E)).
+destruct H19 as [k [H23 [H24 H25]]].
+rewrite H24.
+rewrite (@angle_produit_positif_r2 k B D B C);auto.
+apply consAD_orient_consAV;auto.
+apply cocyclicite;auto with geo.
+apply sont_cocycliques_avec_ordre_cycle.
+apply sont_cocycliques_avec_ordre_cycle;auto.
+apply orient_cycle;apply orient_cycle;auto.
+apply orient_cycle;apply orient_cycle;auto.
+
+
+assert ( H24 : trianglesSD E C D  B C A ).
+unfold trianglesSD.
+repeat split  ;auto with geo.
+unfold triangle.
+red;intros.
+destruct H18 as [k [_ [H24 H25]]].
+assert (alignes D B E) by (apply (@colineaire_alignes k);auto).
+assert (alignes E D B) by (apply alignes_ordre_cycle2;auto).
+assert (alignes E D C) by (apply alignes_ordre_permute;auto).
+assert (alignes D B C) by (apply alignes_trans2 with (A :=E);auto).
+assert (alignes C D B) by (apply alignes_ordre_cycle2;auto).
+elim H16;auto.
+
+assert ( H25 : trianglesSD E B C D A C ).
+unfold trianglesSD.
+repeat split  ;auto with geo.
+unfold triangle.
+red;intros.
+destruct H19 as [k [_ [H25 H26]]].
+assert (alignes B D E) by (apply (@colineaire_alignes k);auto).
+assert (alignes E B D) by (apply alignes_ordre_cycle2;auto).
+assert (alignes B C D) by (apply alignes_trans2 with (A :=E);auto).
+assert (alignes C D B) by (apply alignes_ordre_cycle;auto).
+elim H16;auto.
+
+destruct (@trianglesSD_proportion E C D B C A H24)
+ as [k [H26 [H27 [H28 H29]]]].
+assert (H30: distance E D * distance C A =distance B A * distance C D).
+rewrite H26.
+rewrite H28.
+ring.
+rewrite (@distance_sym C A) in H30.
+rewrite (@distance_sym B A) in H30.
+destruct (@trianglesSD_proportion E B C D A C H25)
+ as [k' [H31 [H32 [H33 H34]]]].
+assert (H35: distance E B * distance A C =distance B C * distance D A).
+rewrite H32.
+rewrite H31.
+ring.
+rewrite (@distance_sym E B) in H35.
+assert (H36 : distance B D = distance B E + distance E D) by
+  (apply (@EntreDeuxPoint B D E H19 H18)).
+rewrite H36.
+rewrite <-H30.
+rewrite <-H35.
+ring.
+Qed.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The axiomatisation for affine Euclidean space is in a non analytic setting.
 
 - Author(s):
   - Frédérique Guilhot (initial)
+  - Tuan-Minh Pham (concept of orientation and Ptolemy's theorem)
 - Coq-community maintainer(s):
   - Laurent Théry ([**@thery**](https://github.com/thery))
 - License: [GNU Lesser General Public License v2.1 or later](LICENSE)

--- a/_CoqProject
+++ b/_CoqProject
@@ -64,4 +64,6 @@ complexes_inversion.v
 complexes_analytique.v
 complements_cercle.v
 exercice_morley.v
-
+triangles_semblables.v
+orientation.v
+Ptolemee.v

--- a/orientation.v
+++ b/orientation.v
@@ -1,0 +1,990 @@
+Require Export aire_signee.
+Require Export angles_droites.
+Require Export angles_vecteurs.
+Require Export Droite_espace.
+Require Export triangles_semblables.
+Definition orient ( A B C :PO) : Prop :=
+     aire (vec A B) (vec A C) >0.
+
+Lemma orient_cycle :
+    forall (A B C :PO), orient A B C -> orient B C A.
+intros A B C H.
+unfold orient in *.
+rewrite aire_ordre_cycle ;auto.
+Qed.
+
+
+Lemma orient_compensation :
+    forall (A B C :PO), ~orient A B C \/ ~orient B A C .
+intros A B C.
+elim (classic (orient A B C));(intros H;auto).
+assert (H0 : orient B C A ) by (apply orient_cycle ;auto).
+right;red;intros H1.
+unfold orient in *.
+rewrite aire_anti_symetrique in H1.
+lra.
+Qed.
+
+Lemma position_3points_1:
+   forall (A B C :PO), (~ orient A B C /\ ~ orient B A C) \/ ~ alignes A B C.
+intros A B C.
+elim (classic (~ orient A B C /\ ~ orient B A C));(intros H;auto).
+right.
+elim (@not_and_or (~orient A B C)(~orient B A C));auto;intro H1.
+assert(orient A B C) by (apply NNPP;auto).
+red;intros H2.
+unfold orient in H0.
+assert ( aire (vec A B)(vec A C) = 0) by apply (@aire_alignement A B C H2) .
+lra.
+
+assert(orient B A C) by (apply NNPP;auto).
+red;intros H2.
+assert (alignes B A C);auto with geo.
+unfold orient in H0.
+assert ( aire (vec B A)(vec B C) = 0) by apply (@aire_alignement B A C H3) .
+lra.
+Qed.
+
+Lemma position_3points_2:
+   forall (A B C :PO), orient A B C \/ orient B A C \/ alignes A B C.
+intros A B C .
+destruct (@total_order_T (aire (vec A B)(vec A C)) 0) as [[H | H ] |H].
+right;left.
+apply orient_cycle;apply orient_cycle.
+unfold orient.
+rewrite aire_anti_symetrique;lra.
+elim (classic (A=B));intros H0.
+right;right.
+rewrite H0;auto with geo.
+destruct (@aire_nulle_colineaires A B A C H0 H) as [k H1].
+right;right.
+apply  colineaire_alignes with (k:=k);auto.
+left.
+unfold orient;auto.
+Qed.
+Lemma orient_4point:
+(*correspondant un axiom de Knuth
+  prouve grace a l'axiom position_4points *)
+forall (A B C D : PO), orient A B D -> orient B C D ->
+          orient C A D -> orient A B C.
+intros A B C D H0 H1 H2.
+unfold orient in *.
+rewrite aire_ordre_cycle2 in H2.
+assert (H4:aire (vec A D) (vec B A) >0).
+rewrite aire_anti_symetrique.
+VReplace (vec B A) (mult_PP (-1) (vec A B)).
+rewrite aire_colineaire_l;lra.
+assert (H5: aire (vec A D) (vec B C) >0).
+rewrite <-(@Chasles_vec B A C).
+rewrite aire_distrib_l;lra.
+assert (H6 : aire (vec D B)(vec B C)>0).
+rewrite aire_anti_symetrique.
+VReplace (vec D B) (mult_PP (-1) (vec B D)).
+rewrite aire_colineaire_r;lra.
+assert (H7: aire (vec A B) (vec B C) >0).
+rewrite <-(@Chasles_vec A D B).
+rewrite aire_distrib_r;lra.
+rewrite <-(@Chasles_vec A B C ).
+rewrite aire_distrib_l.
+rewrite aire_ABAB;lra.
+Qed.
+
+Lemma orient_deroule :
+    forall ( A B C :PO), orient A B C ->
+             ~orient B A C /\ ~alignes A B C /\
+             A<>B /\ A <> C /\ B<>C.
+intros A B C H.
+cut (~orient B A C);intro H0.
+cut (~alignes A B C);intro H1.
+repeat split;auto.
+red;intro H2.
+rewrite H2 in H.
+assert (alignes B B C ) by intuition.
+rewrite H2 in H1.
+elim H1;assumption.
+red;intro H2.
+rewrite H2 in H.
+assert (alignes C B C ) by intuition.
+rewrite H2 in H1.
+elim H1;assumption.
+red;intro H2.
+rewrite H2 in H1.
+assert (alignes A C C ) by intuition.
+elim H1;assumption.
+destruct (position_3points_1 A B C) as [[H2 H3]|h4] ;intuition.
+elim (orient_compensation A B C );intros H1;elim H1;auto.
+Qed.
+
+
+Ltac deroule_orient H:=
+(*find out others trivial hypotheses from the one*)
+(*  match goal with H : orient ?A ?B ?C|- _ =>*)
+  generalize H; let name := fresh in intros name ; decompose [and] (@orient_deroule _ _ _ name ).
+(*end.*)
+
+Definition  positifColineaire ( A B M:PO):Prop :=
+       exists k :R, A <> B /\ vec A M = mult_PP k (vec A B) /\ k>0.
+
+Definition  negatifColineaire ( A B M:PO):Prop :=
+       exists k :R, A <> B /\ vec A M = mult_PP k (vec A B) /\ k<0.
+
+Axiom colineaire_position :
+      forall A B C :PO, A<>B->
+              C = A \/ positifColineaire A B C \/ negatifColineaire A B C.
+Axiom positifColineaire_permute :
+      forall A B C :PO, positifColineaire A B C -> positifColineaire A C B.
+Axiom positifColineaire_negatifColineaire :
+       forall A B C :PO, positifColineaire A B C ->
+                B=C \/ negatifColineaire C B A \/ negatifColineaire B C A  .
+Axiom positifColineaire_negatifColineaire1 :
+       forall A B C :PO, positifColineaire A B C ->
+                positifColineaire B A C -> negatifColineaire C B A  .
+
+Axiom negatifColineaire_permute :
+      forall A B C :PO, negatifColineaire A B C -> negatifColineaire A C B.
+Axiom negatifColineaire_positifColineaire :
+       forall A B C :PO, negatifColineaire A B C ->
+                positifColineaire C A B /\ positifColineaire B A C.
+
+Lemma inversion_colineaire :
+ forall (k : R) (A B C : PO),
+ A <> C -> vec A C = mult_PP k (vec A B) -> vec A B = mult_PP (/ k) (vec A C).
+intros.
+cut (k <> 0); intros.
+rewrite H0.
+Fieldvec k.
+contrapose H.
+apply vecteur_nul_conf.
+rewrite H0; rewrite H1; Ringvec.
+Qed.
+
+Lemma alignes_positifColineaire :
+           forall ( A B M :PO), A<>B ->alignes A B M ->
+                    positifColineaire A B M \/ positifColineaire B A M.
+intros A B M H H0.
+elim H0;intros H1.
+elim H;auto.
+assert (H2: col_vec A B A M) by (apply alignes1_colineaire;auto).
+elim H2;intros k H3.
+elim (Rle_or_lt k 0);intro H4.
+
+assert ( H5 : vec B M =mult_PP (1-k) (vec B A)).
+rewrite <-(Chasles_vec B A M) .
+rewrite ->(opp_vecteur A B) .
+rewrite H3.
+rewrite (mult_mult_vec A B (1-k) (-1)).
+replace ((1-k)* -1) with (k-1); [idtac | ring].
+assert (H6: add_PP (mult_PP (-1) (vec A B))(mult_PP k (vec A B))=
+                   mult_PP (-1 +k) (vec A B )) by RingPP.
+rewrite H6.
+replace (-1 + k ) with (k-1);[auto|ring].
+assert (H7: 1-k >0).
+lra.
+right;unfold positifColineaire.
+exists (1-k);auto.
+left;unfold positifColineaire.
+exists k;auto.
+Qed.
+
+
+(* BEGIN consequences *)
+Lemma positifColineaire_orient_l:
+forall (A B C M :PO), orient A B C -> positifColineaire A B M ->
+          orient A M C.
+intros A B C M H [k [H0 [H1 H2]]].
+unfold orient in *.
+rewrite H1.
+rewrite aire_colineaire_l.
+apply Rmult_gt_0_compat;auto.
+Qed.
+
+Lemma negatifColineaire_orient_l:
+forall (A B C M :PO), orient A B C -> negatifColineaire A B M ->
+          orient A C M.
+intros A B C M H [k [H0 [H1 H2]]].
+unfold orient in *.
+rewrite H1.
+rewrite aire_colineaire_r.
+rewrite aire_anti_symetrique.
+rewrite  Ropp_mult_distr_r_reverse.
+rewrite <- Ropp_mult_distr_l_reverse.
+apply Rmult_gt_0_compat;auto with real.
+Qed.
+
+Lemma positifColineaire_orient_r:
+forall (A B C M :PO), orient A B C -> positifColineaire A C M ->
+          orient A B M.
+intros A B C M H [k [H0 [H1 H2]]].
+unfold orient in *.
+rewrite H1.
+rewrite aire_colineaire_r.
+apply Rmult_gt_0_compat;auto.
+Qed.
+
+Lemma negatifColineaire_orient_r:
+forall (A B C M :PO), orient A B C -> negatifColineaire A C M ->
+          orient A M B.
+intros A B C M H [k [H0 [H1 H2]]].
+unfold orient in *.
+rewrite H1.
+rewrite aire_colineaire_l.
+rewrite aire_anti_symetrique.
+rewrite  Ropp_mult_distr_r_reverse.
+rewrite <- Ropp_mult_distr_l_reverse.
+apply Rmult_gt_0_compat;auto with real.
+Qed.
+
+
+Lemma positifColineaire_orient_inv_l:
+forall (A B C M :PO), orient A B C -> orient A M C ->
+          alignes A B M -> positifColineaire A B M.
+intros A B C M H H0 H1 .
+destruct H1 as [H2|H3].
+deroule_orient H.
+elim H4;auto.
+assert (H2: col_vec A B A M) by (apply alignes1_colineaire;auto).
+destruct H2 as [k H4].
+destruct (@total_order_T k 0) as [[H1 | H1] |H1].
+assert(orient A C M).
+apply negatifColineaire_orient_l with (B:=B);auto.
+exists k; deroule_orient H;auto.
+destruct (orient_compensation C M A);elim H5;apply orient_cycle;auto.
+assert ( A = M) by (apply (@produit_zero_conf k A M A B);auto).
+deroule_orient H0.
+elim H7;auto.
+unfold positifColineaire.
+exists k;repeat split;auto.
+deroule_orient H;auto.
+Qed.
+
+Lemma positifColineaire_orient_inv_r:
+forall (A B C M :PO), orient A B C -> orient A B M  ->
+           alignes A C M ->  positifColineaire A C M.
+intros A B C M H H0 H1 .
+destruct H1 as [H2|H3].
+deroule_orient H.
+elim H6;auto.
+assert (H2: col_vec A C A M) by (apply alignes1_colineaire;auto).
+destruct H2 as [k H4].
+destruct (@total_order_T k 0) as [[H1 | H1] |H1].
+assert(orient A M B).
+apply negatifColineaire_orient_r with (C:=C) ;auto.
+exists k;deroule_orient H;auto.
+destruct (orient_compensation B M A);elim H5;apply orient_cycle;auto.
+assert ( A = M) by (apply (@produit_zero_conf k A M A C);auto).
+deroule_orient H0.
+elim H9;auto.
+unfold positifColineaire.
+exists k;repeat split;auto.
+deroule_orient H;auto.
+Qed.
+
+
+Lemma negatifColineaire_orient_inv_l:
+forall (A B C M :PO), orient A B C -> orient A C M->alignes A B M->
+          negatifColineaire A B M.
+intros A B C M H H0 H1.
+destruct H1 as [H2|H2].
+deroule_orient H.
+elim H4;auto.
+destruct (@alignes1_colineaire A B M) as [k H3];auto.
+destruct (@Rtotal_order k 0) as [H4 |[H4|H4]].
+exists k;deroule_orient H;auto.
+rewrite H4 in H3.
+assert ( A =M) by (apply (@produit_zero_conf 0 A M A B);auto).
+deroule_orient H0.
+elim H9;auto.
+assert (H5 : orient A M C).
+apply (@positifColineaire_orient_l A B C M ); auto.
+exists k;deroule_orient H;auto.
+elim (@orient_compensation A M C);intros H6;elim H6;
+   [auto |apply orient_cycle;apply orient_cycle;auto].
+Qed.
+
+Lemma negatifColineaire_orient_inv_r:
+forall (A B C M :PO), orient A B C -> orient A M B->alignes A C M->
+          negatifColineaire A C M.
+intros A B C M H H0 H1.
+destruct H1 as [H2|H2].
+deroule_orient H.
+elim H6;auto.
+destruct (@alignes1_colineaire A C M) as [k H3];auto.
+destruct (@Rtotal_order k 0) as [H4 |[H4|H4]].
+exists k;deroule_orient H;auto.
+rewrite H4 in H3.
+assert ( A =M) by (apply (@produit_zero_conf 0 A M A C);auto).
+deroule_orient H0.
+elim H7;auto.
+assert (H5 : orient A B M ).
+apply (@positifColineaire_orient_r A B C M ); auto.
+exists k;deroule_orient H; auto.
+elim (@orient_compensation A B M );intros H6;elim H6;
+   [auto |apply orient_cycle;apply orient_cycle;auto].
+Qed.
+
+
+
+
+(* Lemma for angle and orientation *)
+Lemma orient_SinusPositif :
+forall A B C  :PO,
+           orient A B C-> Sin (cons_AV (vec A B )(vec A C ))>0.
+intros A B C H.
+generalize H;intros H0.
+unfold orient in H0.
+rewrite def_aire in *;deroule_orient H;auto.
+elim (@distance_pos A B );intros H10 ;
+      [idtac|elim (@distincts_dist_non_nulle A B H3);auto].
+elim (@distance_pos A C );intros H11 ;
+      [idtac|elim (@distincts_dist_non_nulle A C H5);auto].
+assert (H9 :0< distance A C * Sin(cons_AV (vec A B )(vec A C)) ).
+apply Rmult_lt_reg_l with (r:= distance A B);auto with real.
+replace (distance A B *0)  with 0  ;auto with real.
+red.
+apply Rmult_lt_reg_l with (r:= distance A C);auto with real.
+replace (distance A C *0)  with 0  ;auto with real.
+Qed.
+
+Lemma anglesEgaux_orient :
+forall (A B C M N P : PO), orient A B C -> M<>N -> M <>P->
+         cons_AV (vec M N) (vec M P) = cons_AV (vec A B ) ( vec A C)->
+         orient M N P.
+intros A B C M N P H H0 H1 H2.
+generalize H;intros H3.
+unfold orient in H3.
+unfold orient .
+rewrite def_aire in *;deroule_orient H;auto.
+elim (@distance_pos A B );intros H11 ;
+      [idtac|elim (@distincts_dist_non_nulle A B H6);auto].
+elim (@distance_pos A C );intros H12 ;
+      [idtac|elim (@distincts_dist_non_nulle A C H8);auto].
+elim (@distance_pos M N );intros H13 ;
+      [idtac|elim (@distincts_dist_non_nulle M N H0);auto].
+elim (@distance_pos M P );intros H14 ;
+      [idtac|elim (@distincts_dist_non_nulle M P H1);auto].
+rewrite H2.
+apply Rmult_gt_0_compat;auto.
+apply Rmult_gt_0_compat;auto.
+replace 0 with (distance A B *0) in H3;auto with real.
+apply orient_SinusPositif;auto.
+Qed.
+
+Lemma  consAD_orient_consAV:
+forall A B C M N P :PO,
+double_AV (cons_AV (vec A B)(vec A C))= double_AV (cons_AV (vec M N) (vec M P))->
+orient A B C -> orient M N P ->
+cons_AV (vec A B) (vec A C) = cons_AV (vec M N) (vec M P).
+intros A B C M N P H H0 H1.
+unfold double_AV in H.
+deroule_orient H0.
+deroule_orient H1.
+destruct  (tout_angle_a_une_mesure (A:=A) (B:=B) (C:=A) (D:=C)) as [x H15]; auto with geo.
+destruct  (tout_angle_a_une_mesure (A:=M) (B:=N) (C:=M) (D:=P)) as [y H16]; auto with geo.
+rewrite <-H15 in *.
+rewrite <-H16 in *.
+rewrite <-add_mes_compatible in H.
+rewrite <-add_mes_compatible in H.
+replace (x+x) with (2*x) in H.
+replace (y+y) with (2*y) in H.
+cut (sin x = sin y).
+intros H17.
+cut (cos x = cos y).
+intros H18.
+apply egalite_angle_trigo;auto.
+assert (H19:sin (2*x) = sin (2*y)) by (apply sin_deux_mes;auto).
+repeat rewrite duplication_sin in H19.
+rewrite H17 in H19.
+apply Rmult_eq_reg_l with (r:=sin y).
+apply Rmult_eq_reg_l with (r:=2);auto with real.
+apply Rgt_not_eq.
+rewrite (@egalite_sin_Sin M N P y);auto.
+apply orient_SinusPositif;auto.
+assert (H19:cos (2*x) = cos (2*y)) by (apply cos_deux_mes;auto).
+repeat rewrite duplication_cos2 in H19.
+apply Rsqr_inj.
+assert (sin x >0) by
+(rewrite (@egalite_sin_Sin A B C x);auto; apply orient_SinusPositif;auto).
+lra.
+assert (sin y >0) by
+(rewrite (@egalite_sin_Sin M N P y);auto; apply orient_SinusPositif;auto).
+lra.
+apply Rmult_eq_reg_l with (r:=2);auto with real.
+assert (-(2*Rsqr (sin x)) = -((2*Rsqr (sin y)))) by (apply Rplus_eq_reg_l with (r:=1);auto with real).
+replace (2 * Rsqr(sin x)) with (-(-(2 * Rsqr(sin x))));auto with real.
+replace (2 * Rsqr(sin y)) with (-(-(2 * Rsqr(sin y))));auto with real.
+ring.
+ring.
+Qed.
+
+Lemma  consAD_orient_consAVplusPi:
+forall A B C M N P :PO,
+double_AV (cons_AV (vec A B)(vec A C))= double_AV (cons_AV (vec M N) (vec M P))->
+orient A B C -> orient M P N ->
+cons_AV (vec A B) (vec A C) = plus (cons_AV (vec M N) (vec M P)) (image_angle pi).
+intros A B C M N P H H0 H1.
+unfold double_AV in H.
+deroule_orient H0.
+deroule_orient H1.
+destruct  (tout_angle_a_une_mesure (A:=A) (B:=B) (C:=A) (D:=C)) as [x H15]; auto with geo.
+destruct  (tout_angle_a_une_mesure (A:=M) (B:=N) (C:=M) (D:=P)) as [y H16]; auto with geo.
+rewrite <-H15 in *.
+rewrite <-H16 in *.
+rewrite <-add_mes_compatible in H.
+rewrite <-add_mes_compatible in H.
+replace (x+x) with (2*x) in H; [idtac|ring].
+replace (y+y) with (2*y) in H; [idtac|ring].
+cut (sin x = -sin y).
+intros H17.
+cut (cos x = -cos y).
+intros H18.
+rewrite <-add_mes_compatible.
+apply egalite_angle_PiPres_trigo;auto.
+assert (H19:sin (2*x) = sin (2*y)) by (apply sin_deux_mes;auto).
+repeat rewrite duplication_sin in H19.
+rewrite H17 in H19.
+replace (cos x) with ( - -cos x);auto with real.
+apply Ropp_eq_compat.
+apply Rmult_eq_reg_l with (r:=sin y).
+apply Rmult_eq_reg_l with (r:=2);auto with real.
+rewrite <-H19.
+rewrite Ropp_mult_distr_l_reverse.
+rewrite Ropp_mult_distr_r_reverse;auto.
+
+assert (Sin (cons_AV(vec M P)(vec M N)) >0) by (apply orient_SinusPositif;auto).
+assert (cons_AV (vec M P) (vec M N) = opp (cons_AV (vec M N) (vec M P))).
+apply opp_angle.
+rewrite Chasles;auto.
+rewrite <-angle_nul;auto.
+rewrite <-H16 in H18.
+rewrite <-mes_opp in H18.
+rewrite <-(@egalite_sin_Sin M P N (-y)) in H13;auto.
+rewrite  sin_impaire in H13.
+assert (sin y <0).
+lra.
+apply Rlt_not_eq;auto.
+
+assert (H19:cos (2*x) = cos (2*y)) by (apply cos_deux_mes;auto).
+repeat rewrite duplication_cos2 in H19.
+rewrite (@Rsqr_neg (sin y)) in H19.
+apply Rsqr_inj.
+assert (sin x >0) by
+(rewrite (@egalite_sin_Sin A B C x);auto; apply orient_SinusPositif;auto).
+lra.
+
+assert (Sin (cons_AV(vec M P)(vec M N)) >0) by (apply orient_SinusPositif;auto).
+assert (cons_AV (vec M P) (vec M N) = opp (cons_AV (vec M N) (vec M P))).
+apply opp_angle.
+rewrite Chasles;auto.
+rewrite <-angle_nul;auto.
+rewrite <-H16 in H17.
+rewrite <-mes_opp in H17.
+rewrite <-(@egalite_sin_Sin M P N (-y)) in H13;auto.
+rewrite  sin_impaire in H13.
+lra.
+apply Rmult_eq_reg_l with (r:=2);auto with real.
+assert (-(2*Rsqr (sin x)) = -((2*Rsqr (-sin y)))) by (apply Rplus_eq_reg_l with (r:=1);auto with real).
+replace (2 * Rsqr(sin x)) with (-(-(2 * Rsqr(sin x))));auto with real.
+replace (2 * Rsqr(-sin y)) with (-(-(2 * Rsqr(-sin y))));auto with real.
+Qed.
+
+
+
+
+(*  Des consequences concernant l'intersection*)
+Definition vecEntreDeuxVec ( A B C M :PO) : Prop :=
+           (orient A B C /\ orient A B M /\ orient A M C)\/
+           (orient A C B /\ orient A C M /\ orient A M B).
+
+Lemma (*lemme*) vecEntreDeuxVec_permute :
+forall ( A B C M :PO), vecEntreDeuxVec A B C M ->
+          vecEntreDeuxVec A C B M.
+intros A B C M [[H0 [H1 H2]]|[H0 [H1 H2]]].
+right;auto.
+left;auto.
+Qed.
+
+Lemma vecEntreDeuxVec_intersection_middle1:
+           forall ( A B C D :PO),orient A B C -> vecEntreDeuxVec A B C D ->
+           forall M:PO, alignes A D M /\ alignes B C M ->
+           positifColineaire A D M.
+intros A B C D H H0 M [H2 H1] .
+elim H0;intros [H3 [H4 H5]].
+destruct H2 as [H2|H2].
+deroule_orient H5;elim H8;auto.
+destruct (@alignes1_colineaire A D M) as [k H6];auto.
+destruct (@Rtotal_order k 0) as [H7|[H7|H7]].
+assert (orient A C M)
+  by (apply (@negatifColineaire_orient_l A D C M H5 );auto;
+  exists k; deroule_orient H5;auto).
+assert (orient A M B)
+  by (apply (@negatifColineaire_orient_r A B D M H4 );auto;
+  exists k; deroule_orient H4;auto).
+assert (orient M B C).
+apply orient_4point with (D:=A);auto.
+apply orient_cycle; auto.
+apply orient_cycle;auto.
+apply orient_cycle;auto.
+deroule_orient H10.
+elim H14;apply alignes_ordre_cycle2;auto.
+assert (A=M) by (apply produit_zero_conf with (k:=k) (C:=A)(D:=D);auto).
+rewrite <-H8 in H1.
+deroule_orient H3.
+elim H12;auto with geo.
+exists k;repeat split;auto.
+deroule_orient H5;auto.
+destruct  (@orient_compensation A B C) as [H6|H6].
+elim H6;auto.
+elim H6;apply orient_cycle;apply orient_cycle;auto.
+Qed.
+
+
+Lemma vecEntreDeuxVec_intersection_middle2:
+           forall ( A B C D  :PO),orient A B C -> vecEntreDeuxVec A B C D ->
+           forall M:PO, alignes A D M /\ alignes B C M ->
+           positifColineaire B C M /\ positifColineaire C B M.
+intros A B C D  H H0 M [H2 H1].
+elim H0;intros [H3 [H4 H5]].
+assert (positifColineaire A D M) by  (apply(@vecEntreDeuxVec_intersection_middle1 A B C D );auto).
+assert (orient A B M) by (apply positifColineaire_orient_r with (C:=D);auto).
+assert (orient A M C) by (apply  positifColineaire_orient_l with (B:=D);auto).
+split.
+apply (@positifColineaire_orient_inv_l B C A M);auto.
+apply orient_cycle;assumption.
+apply orient_cycle;assumption.
+apply (@positifColineaire_orient_inv_r C A B M);auto.
+apply orient_cycle;apply orient_cycle;assumption.
+apply orient_cycle;apply orient_cycle;assumption.
+apply permute_alignes;assumption.
+destruct  (@orient_compensation A B C) as [H6|H6].
+elim H6;auto.
+elim H6;apply orient_cycle;apply orient_cycle;auto.
+Qed.
+
+Lemma vecEntreDeuxVec_intersection_middle:
+           forall ( A B C D :PO), vecEntreDeuxVec A B C D ->
+           forall M:PO, alignes A D M /\ alignes B C M ->
+           positifColineaire B C M /\ positifColineaire C B M /\ positifColineaire A D M.
+intros A B C D H M [H1 H0].
+elim H;intros [H2 [H3 H4]].
+assert (positifColineaire B C M /\ positifColineaire C B M).
+apply (@vecEntreDeuxVec_intersection_middle2 A B C D );auto.
+assert (positifColineaire A D M).
+apply (@vecEntreDeuxVec_intersection_middle1 A B C D );auto.
+destruct H5 as [H7 H8].
+split;auto.
+assert (vecEntreDeuxVec A C B D) by
+        (unfold vecEntreDeuxVec;left;split;auto).
+assert (positifColineaire C B M /\ positifColineaire B C M).
+apply (@vecEntreDeuxVec_intersection_middle2 A C B D );auto with geo.
+assert (positifColineaire A D M).
+apply (@vecEntreDeuxVec_intersection_middle1 A C B D );auto with geo.
+destruct H6 as [H8 H9].
+split;auto.
+Qed.
+
+Lemma vecEntreDeuxVec_intersection_left1:
+           forall ( A B C D :PO), vecEntreDeuxVec A B C D ->
+           forall M :PO, alignes A B M /\ alignes C D M ->
+           (positifColineaire C D M -> positifColineaire A B M) /\
+           (positifColineaire A B M -> positifColineaire C D M /\ positifColineaire M D C ) .
+intros A B C D H M [H3 H2].
+repeat split.
+intro H1.
+destruct H as [[H19 [H20 H21]] |[H19 [H20 H21]]].
+assert (H4 : orient A M C).
+apply orient_cycle.
+apply positifColineaire_orient_r with (C:=D);auto.
+apply orient_cycle;apply orient_cycle;auto.
+apply positifColineaire_orient_inv_l with (C:=C);auto.
+assert (H4 : orient A C M).
+apply orient_cycle;apply orient_cycle.
+apply positifColineaire_orient_l with (B:=D);auto.
+apply orient_cycle;auto.
+apply positifColineaire_orient_inv_r with (B:=C);auto.
+
+destruct H as [[H19 [H20 H21]] |[H19 [H20 H21]]].
+assert (H4 : orient C A M ).
+apply orient_cycle;apply orient_cycle;auto.
+apply positifColineaire_orient_l with (B:=B);auto.
+apply positifColineaire_orient_inv_r with (B:=A);auto.
+apply orient_cycle;apply orient_cycle;auto.
+assert (H4 : orient C M A ).
+apply orient_cycle;auto.
+apply positifColineaire_orient_r with (C:=B);auto.
+apply positifColineaire_orient_inv_l with (C:=A);auto.
+apply orient_cycle;auto.
+
+
+
+destruct H as [[H19 [H20 H21]] |[H19 [H20 H21]]].
+assert (H4 : orient M C A ).
+apply orient_cycle.
+apply positifColineaire_orient_l with (B:=B);auto.
+assert (H5 : orient M D A ).
+apply orient_cycle.
+apply positifColineaire_orient_l with (B:=B);auto.
+apply positifColineaire_orient_inv_l with (C:=A);auto with geo.
+assert (H4 : orient M A C ).
+apply orient_cycle;apply orient_cycle.
+apply positifColineaire_orient_r with (C:=B);auto.
+assert (H5 : orient M A D ).
+apply orient_cycle;apply orient_cycle.
+apply positifColineaire_orient_r with (C:=B);auto.
+apply positifColineaire_orient_inv_r with (B:=A);auto with geo.
+Qed.
+
+Lemma vecEntreDeuxVec_intersection_left2:
+           forall ( A B C D :PO), vecEntreDeuxVec A B C D ->
+           forall M :PO, alignes A B M /\ alignes C D M ->
+           (negatifColineaire C D M -> negatifColineaire A B M) /\
+           (negatifColineaire A B M -> negatifColineaire C D M  ) .
+intros A B C D H M [H3 H2].
+repeat split;intro H1.
+destruct H as [[H19 [H20 H21]] |[H19 [H20 H21]]].
+assert (H4 : orient A C M).
+apply orient_cycle;apply orient_cycle.
+apply negatifColineaire_orient_r with (C:=D);auto.
+apply orient_cycle;apply orient_cycle;auto.
+apply negatifColineaire_orient_inv_l with (C:=C);auto.
+assert (H4 : orient A M C ).
+apply orient_cycle.
+apply negatifColineaire_orient_l with (B:=D);auto.
+apply orient_cycle;auto.
+apply negatifColineaire_orient_inv_r with (B:=C);auto.
+
+destruct H as [[H19 [H20 H21]] |[H19 [H20 H21]]].
+assert (H4 : orient C M A ).
+apply orient_cycle.
+apply negatifColineaire_orient_l with (B:=B);auto.
+apply negatifColineaire_orient_inv_r with (B:=A);auto.
+apply orient_cycle;apply orient_cycle;auto.
+assert (H4 : orient C A M  ).
+apply orient_cycle;apply orient_cycle.
+apply negatifColineaire_orient_r with (C:=B);auto.
+apply negatifColineaire_orient_inv_l with (C:=A);auto.
+apply orient_cycle;auto.
+Qed.
+
+
+Lemma vecEntreDeuxVec_intersection_right1:
+           forall ( A B C D :PO), vecEntreDeuxVec A B C D ->
+           forall M :PO, alignes A C M /\ alignes B D M ->
+           (positifColineaire B D M -> positifColineaire A C M) /\
+           (positifColineaire A C M -> positifColineaire B D M /\ positifColineaire M D B ) .
+intros A B C  D H M [H3 H2].
+repeat split.
+intro H1.
+destruct H as [[H19 [H20 H21]] |[H19 [H20 H21]]].
+assert (H4 : orient A B M).
+apply orient_cycle;apply orient_cycle.
+apply positifColineaire_orient_l with (B:=D);auto.
+apply orient_cycle;auto.
+apply positifColineaire_orient_inv_r with (B:=B);auto.
+assert (H4 : orient A M B).
+apply orient_cycle.
+apply positifColineaire_orient_r with (C:=D);auto.
+apply orient_cycle;apply orient_cycle;auto.
+apply positifColineaire_orient_inv_l with (C:=B);auto.
+
+destruct H as [[H19 [H20 H21]] |[H19 [H20 H21]]].
+assert (H4 : orient B M A ).
+apply orient_cycle;auto.
+apply positifColineaire_orient_r with (C:=C);auto.
+apply positifColineaire_orient_inv_l with (C:=A);auto.
+apply orient_cycle;auto.
+assert (H4 : orient B A M ).
+apply orient_cycle;apply orient_cycle;auto.
+apply positifColineaire_orient_l with (B:=C);auto.
+apply positifColineaire_orient_inv_r with (B:=A);auto.
+apply orient_cycle;apply orient_cycle;auto.
+
+
+
+destruct H as [[H19 [H20 H21]] |[H19 [H20 H21]]].
+assert (H4 : orient M A B ).
+apply orient_cycle;apply orient_cycle.
+apply positifColineaire_orient_r with (C:=C);auto.
+assert (H5 : orient M A D ).
+apply orient_cycle;apply orient_cycle.
+apply positifColineaire_orient_r with (C:=C);auto.
+apply positifColineaire_orient_inv_r with (B:=A);auto with geo.
+assert (H4 : orient M B A ).
+apply orient_cycle.
+apply positifColineaire_orient_l with (B:=C);auto.
+assert (H5 : orient M D A ).
+apply orient_cycle.
+apply positifColineaire_orient_l with (B:=C);auto.
+apply positifColineaire_orient_inv_l with (C:=A);auto with geo.
+Qed.
+
+Lemma vecEntreDeuxVec_intersection_right2:
+           forall ( A B C D :PO), vecEntreDeuxVec A B C D ->
+           forall M :PO, alignes A C M /\ alignes B D M ->
+           (negatifColineaire B D M -> negatifColineaire A C M) /\
+           (negatifColineaire A C M -> negatifColineaire B D M  ) .
+intros A B C D H M [H3 H2].
+repeat split;intro H1.
+destruct H as [[H19 [H20 H21]] |[H19 [H20 H21]]].
+assert (H4 : orient A M B ).
+apply orient_cycle.
+apply negatifColineaire_orient_l with (B:=D);auto.
+apply orient_cycle;auto.
+apply negatifColineaire_orient_inv_r with (B:=B);auto.
+assert (H4 : orient A B M ).
+apply orient_cycle;apply orient_cycle.
+apply negatifColineaire_orient_r with (C:=D);auto.
+apply orient_cycle;apply orient_cycle;auto.
+apply negatifColineaire_orient_inv_l with (C:=B);auto.
+
+destruct H as [[H19 [H20 H21]] |[H19 [H20 H21]]].
+assert (H4 : orient B A M  ).
+apply orient_cycle;apply orient_cycle.
+apply negatifColineaire_orient_r with (C:=C);auto.
+apply negatifColineaire_orient_inv_l with (C:=A);auto.
+apply orient_cycle;auto.
+assert (H4 : orient B M A ).
+apply orient_cycle.
+apply negatifColineaire_orient_l with (B:=C);auto.
+apply negatifColineaire_orient_inv_r with (B:=A);auto.
+apply orient_cycle;apply orient_cycle;auto.
+Qed.
+
+
+
+Lemma Exists_Intersection1 : (* on peut prouver grace au lemme
+droites_non_paralleles *)
+forall (A B C D :PO),
+          vecEntreDeuxVec A B C D ->
+          exists E :PO, alignes A D E /\ alignes B C E.
+intros A B C D H.
+assert (H0 : ~alignes A D B /\ A <>D)
+ by(destruct H as [[_ [H2 _]]|[_ [_ H2]]];deroule_orient H2;auto with geo).
+destruct H0 as [H0 H1].
+assert (H2 : ~alignes A D C)
+ by(destruct H as [[_ [_ H3 ]]|[_ [H3 _]]];deroule_orient H3;auto with geo).
+assert (H3 : B<>C)
+ by(destruct H as [[H4 [_ _]]|[H4 [_ _]]];deroule_orient H4;auto with geo).
+destruct (@existence_pt_intersection A D B C ) as [E H4];auto.
+assert (H4: ~ paralleles (droite A D) (droite B C)).
+red;intros H4.
+destruct (@existence_representant_vecteur A B C) as [D' H5].
+destruct (@paralleles_vecteur A D B C ) as [k H6];auto.
+destruct H as [[H7 [H8 H9]]|[H7 [H8 H9]]].
+assert (aire(vec B C)(vec A D) = 0) by (apply aire_colinearite with (k:=k) ;auto).
+rewrite <-(@Chasles_vec B A C) in H.
+rewrite aire_distrib_r in H.
+assert (aire (vec B A)(vec A D) <0).
+VReplace (vec B A) (mult_PP (-1) (vec A B)).
+rewrite aire_colineaire_l.
+unfold orient in H8;lra.
+assert (aire (vec A C)(vec A D) <0).
+rewrite aire_anti_symetrique.
+unfold orient in H9;lra.
+lra.
+assert (aire(vec B C)(vec A D) = 0) by (apply aire_colinearite with (k:=k) ;auto).
+rewrite <-(@Chasles_vec B A C) in H.
+rewrite aire_distrib_r in H.
+assert (aire (vec B A)(vec A D) >0).
+VReplace (vec B A) (mult_PP (-1) (vec A B)).
+rewrite aire_colineaire_l.
+rewrite aire_anti_symetrique.
+unfold orient in H9.
+replace (-1) with (-(1)) by ring.
+rewrite Ropp_mult_distr_l_reverse.
+rewrite Ropp_mult_distr_r_reverse.
+lra.
+assert (aire (vec A C)(vec A D) >0).
+unfold orient in H8;auto.
+lra.
+elim (@droites_non_paralleles  B C A D H3 H1 H4);auto.
+intros H5.
+(*here we use an axiom of plane geometry,
+which one to say that every 4 points are COPLANAR   *)
+assert (H6: coplanaires B C A D) by apply geometrie_plane.
+elim H5;auto.
+exists E;auto.
+apply def_pt_intersection2;auto.
+Qed.
+
+Lemma Exists_Intersection: (* on peut prouver grace au lemme
+droites_non_paralleles *)
+forall (A B C D :PO),
+          vecEntreDeuxVec A B C D ->
+          exists M :PO,positifColineaire B C M /\ positifColineaire C B M /\ positifColineaire A D M.
+intros A B C D H.
+destruct (@Exists_Intersection1 A B C D) as [M [H0 H1]];auto.
+exists M.
+apply vecEntreDeuxVec_intersection_middle;auto.
+Qed.
+
+(*Consequence concernant angles inscrits oriente*)
+Axiom differencePiNull : image_angle 0 <>image_angle pi.
+
+Require Export cocyclicite.
+
+Ltac deroule_sont_cocycliques :=
+  match goal with H : sont_cocycliques ?A ?B ?C ?D|- _ =>
+  generalize H ; let name := fresh in intros name  ;
+  unfold sont_cocycliques in name;
+  destruct name ;decompose [and] name; clear name;
+ repeat match goal with H' : circonscrit ?O ?A ?B ?C  |- _ =>
+  unfold circonscrit  in H';
+  decompose [and] H' ; clear H' end ;
+ repeat match goal with H' : isocele ?O ?A ?B  |- _ =>
+  unfold isocele  in H'
+  end
+end.
+
+Lemma sont_cocycliques_avec_ordre_cycle:
+forall (A B C D :PO),
+         sont_cocycliques A B C D ->sont_cocycliques B C D A.
+intros A B C D H.
+deroule_sont_cocycliques .
+unfold sont_cocycliques .
+exists x.
+unfold circonscrit in *.
+unfold isocele in *.
+repeat split ;auto.
+rewrite H4 in H2;auto.
+rewrite H3 in H0;auto.
+rewrite H4 in H2;auto.
+Qed.
+
+Lemma sont_cocycliques_avec_ordre_permute:
+forall (A B C D :PO),
+         sont_cocycliques A B C D ->sont_cocycliques A B D C.
+intros A B C D H.
+deroule_sont_cocycliques .
+unfold sont_cocycliques .
+exists x.
+unfold circonscrit in *.
+unfold isocele in *.
+repeat split ;auto.
+Qed.
+
+
+
+
+
+
+Theorem SommeAnglesInscritsOriente:
+forall (A B C D : PO),
+         sont_cocycliques A B C D ->orient A B C ->
+                    orient A C D -> orient A B D.
+intros A B C D H H0 H1.
+destruct (@position_3points_2 A B D) as [H2|[H2|H2]];auto.
+assert (H3:orient B C D).
+apply orient_4point with (D:=A);auto.
+apply orient_cycle;auto.
+apply orient_cycle;auto.
+apply orient_cycle;apply orient_cycle;auto.
+
+
+assert (H4:cons_AV(vec A D )(vec A B) = cons_AV (vec C D)(vec C B)).
+apply consAD_orient_consAV.
+apply cocyclicite;auto with geo.
+deroule_orient H2 ;auto with geo.
+deroule_orient H3 ;auto with geo.
+apply sont_cocycliques_avec_ordre_cycle.
+apply sont_cocycliques_avec_ordre_permute.
+apply sont_cocycliques_avec_ordre_cycle;apply sont_cocycliques_avec_ordre_cycle;auto.
+apply orient_cycle;auto.
+apply orient_cycle;auto.
+assert (H5:cons_AV(vec A B )(vec A C) = cons_AV (vec D B)(vec D C)).
+apply consAD_orient_consAV;auto.
+apply cocyclicite;auto with geo.
+deroule_orient H0 ;auto with geo.
+deroule_orient H3 ;auto with geo.
+apply sont_cocycliques_avec_ordre_permute.
+apply sont_cocycliques_avec_ordre_cycle;auto.
+apply orient_cycle;apply orient_cycle;auto.
+assert (H6:cons_AV(vec A C )(vec A D) = cons_AV (vec B C)(vec B D)).
+apply consAD_orient_consAV;auto.
+apply cocyclicite;auto with geo.
+deroule_orient H1 ;auto with geo.
+deroule_orient H3 ;auto with geo.
+apply sont_cocycliques_avec_ordre_cycle.
+apply sont_cocycliques_avec_ordre_cycle;auto.
+assert (plus (cons_AV (vec C D) (vec C B))
+   (plus (cons_AV (vec D B) (vec D C)) (cons_AV (vec B C) (vec B D))) = image_angle pi).
+apply somme_triangle;deroule_orient H3;auto.
+rewrite <-H4 in H7.
+rewrite <-H5 in H7.
+rewrite <-H6 in H7.
+rewrite Chasles in H7;(deroule_orient H0;deroule_orient H1;auto).
+rewrite Chasles in H7;(deroule_orient H0;deroule_orient H1;auto).
+rewrite <-angle_nul in H7;auto.
+
+elim differencePiNull;auto.
+
+assert (H3: col_vec A B A D) .
+apply alignes1_colineaire;auto with geo.
+unfold alignes in H2.
+elim H2;intros;auto.
+deroule_orient H0.
+elim H6;auto.
+destruct H3 as [k H4].
+destruct (@total_order_T k 0) as [[H5| H5] |H5].
+assert (H6: vec B D = mult_PP (1-k) (vec B A)).
+rewrite <-(@Chasles_vec B A D) .
+rewrite H4.
+VReplace (vec A B) (mult_PP (-1) (vec B A)).
+rewrite mult_mult_vec.
+replace (k*-1) with (-k);[idtac|ring].
+replace (1-k) with (1+(-k));auto with real.
+VReplace (vec B A) (mult_PP (1) (vec B A)).
+RingPP.
+assert (H7: 1-k >0).
+lra.
+assert(H8 : orient D B C).
+apply orient_cycle;apply orient_cycle.
+apply positifColineaire_orient_r with (C:=A).
+apply orient_cycle;auto.
+exists (1-k);deroule_orient H0;auto.
+assert (H9:cons_AV(vec D B )(vec D C) = cons_AV (vec A B)(vec A C)).
+apply consAD_orient_consAV;auto.
+apply cocyclicite;auto with geo.
+deroule_orient H8 ;auto with geo.
+deroule_orient H0 ;auto with geo.
+apply sont_cocycliques_avec_ordre_cycle;auto.
+
+assert (trianglesSD C A B C D B ).
+repeat split.
+deroule_orient H0;auto with geo.
+deroule_orient H8;auto with geo.
+auto.
+rewrite (@angle_produit_positif_r (1-k) B A D  B C ) ;auto.
+deroule_orient H0;auto with geo.
+deroule_orient H0;auto with geo.
+assert (cons_AV (vec C A)(vec C B) =cons_AV (vec C D)(vec C B)).
+apply (@trianglesSD_angles_egaux  C A B C D B);auto.
+assert (cons_AV (vec C A) (vec C D) = image_angle 0).
+rewrite <-(@Chasles C A C B C D);(deroule_orient H0;deroule_orient H1;auto with geo).
+rewrite H10.
+rewrite Chasles;auto with geo.
+rewrite (@ angle_nul C D) ;auto.
+destruct (@angle_nul_positif_colineaire C A D) as [k' [H12 H13]];(deroule_orient H0;deroule_orient H1;auto).
+assert (alignes C A D) .
+apply colineaire_alignes with (k:=k');auto.
+elim H23.
+apply   alignes_ordre_permute .
+apply alignes_ordre_cycle;auto.
+
+
+
+
+assert (A=D).
+apply (@produit_zero_conf k A D A B);auto.
+deroule_orient H1.
+elim H10;auto.
+
+assert (orient A D C).
+apply (@positifColineaire_orient_l A B C D H0);auto.
+exists k;deroule_orient H0;auto.
+elim (@orient_compensation D C A);intro.
+elim H6.
+apply orient_cycle;auto.
+
+elim H6.
+apply orient_cycle;auto.
+Qed.

--- a/triangles_semblables.v
+++ b/triangles_semblables.v
@@ -1,0 +1,672 @@
+
+Require Export alignement.
+Require Export angles_vecteurs.
+Require Export rotation_plane.
+Require Export reflexion_plane.
+Require Export dilatations.
+Require Export transformations_contact.
+Require Export  distance_euclidienne.
+
+(* Definition of similar triangles by  equality of 2 angles *)
+Definition trianglesSD (A B C A' B' C' : PO):Prop:=
+                triangle A B C /\ triangle A' B' C' /\
+                cons_AV (vec B C) (vec B A) = cons_AV (vec B' C') (vec B' A') /\
+                cons_AV (vec C A) (vec C B) = cons_AV (vec C' A') (vec C' B' ) .
+
+Definition trianglesSI (A B C A' B' C' : PO):Prop:=
+                triangle A B C /\ triangle A' B' C' /\
+                cons_AV (vec B C) (vec B A) = cons_AV (vec B' A') (vec B' C') /\
+                cons_AV (vec C A) (vec C B) = cons_AV (vec C' B' ) (vec C' A').
+
+Definition triangles_semblables (A B C A' B' C' :PO) :Prop :=
+                trianglesSD A B C A' B' C' \/
+                trianglesSI A B C A' B' C'.
+
+Ltac deroule_triangles_semblables :=
+(*find out others trivial hypotheses from the one*)
+  match goal with H : trianglesSD ?A ?B ?C ?D ?E ?F |- _ =>
+  generalize H; let name := fresh in intros name ; red in name; decompose [and] name;
+  deroule_triangle A B C; deroule_triangle D E F;clear name
+| H : trianglesSI ?A ?B ?C ?D ?E ?F |- _ =>
+  generalize H; let name := fresh in intros name ; red in name; decompose [and] name;
+  deroule_triangle A B C; deroule_triangle D E F; clear name;
+  match goal with H' : _ |- _ => move H after H' end
+end.
+
+
+Lemma trianglesSD_angles_egaux :
+forall A B C A' B' C' :PO,
+trianglesSD A B C A' B' C' -> cons_AV(vec A B) (vec A C) = cons_AV (vec A' B') (vec A' C').
+intros A B C A' B' C' H.
+deroule_triangles_semblables.
+rewrite <- angle_triangle;try auto.
+rewrite -> H2;rewrite -> H5.
+apply angle_triangle;auto .
+Qed.
+Lemma trianglesSI_angles_egaux:
+forall A B C A' B' C' :PO,
+trianglesSI A B C A' B' C'  -> cons_AV (vec A B)(vec A C) = cons_AV (vec A' C') (vec A' B').
+intros A B C A' B' C' H.
+deroule_triangles_semblables.
+rewrite <- angle_triangle;try auto.
+rewrite -> H2;rewrite -> H5.
+rewrite <-somme_triangle with A' C' B'; try auto.
+mesure A' C' A' B'.
+mesure B' A' B' C'.
+mesure C' B' C' A'.
+repeat rewrite <- mes_opp.
+repeat rewrite <-add_mes_compatible.
+replace (x+(x1+x0) + -(x0+x1)) with x; [auto|ring].
+Qed.
+
+
+Ltac expand_triangles_semblables :=
+  deroule_triangles_semblables;
+  match goal with H : trianglesSD ?A ?B ?C ?D ?E ?F |- _ =>
+    generalize H; let name:=fresh in intros name; apply trianglesSD_angles_egaux in name
+  |H : trianglesSI ?A ?B ?C ?D ?E ?F |- _ =>
+    generalize H; let name:=fresh in intros name;  apply trianglesSI_angles_egaux in name ;
+  match goal with H' : _ |- _ => move H after H' end
+end.
+
+
+
+Lemma trianglesSD_ordre_cycle :
+forall A B C A' B' C' :PO,
+trianglesSD A B C A' B' C' -> trianglesSD  B C A B' C' A'.
+intros.
+expand_triangles_semblables.
+repeat split; auto with geo.
+Qed.
+Lemma trianglesSI_ordre_cycle :
+forall A B C A' B' C' :PO,
+trianglesSI A B C A' B' C' -> trianglesSI  B C A B' C' A'.
+intros.
+expand_triangles_semblables.
+repeat split; auto with geo.
+Qed.
+
+Lemma trianglesSD_ordre_permute :
+forall A B C A' B' C' :PO,
+trianglesSD A B C A' B' C' -> trianglesSD  A C B A' C' B' .
+intros.
+expand_triangles_semblables.
+repeat split; auto with geo.
+Qed.
+
+Lemma trianglesSI_ordre_permute :
+forall A B C A' B' C' :PO,
+trianglesSI A B C A' B' C' -> trianglesSI  A C B A' C' B' .
+intros.
+expand_triangles_semblables.
+repeat split; auto with geo.
+Qed.
+
+Hint Resolve trianglesSD_ordre_cycle
+                      trianglesSI_ordre_cycle
+                      trianglesSD_ordre_permute
+                      trianglesSI_ordre_permute
+                      : geo.
+
+
+
+Lemma trianglesSD_ordre_cycle2 :
+forall A B C A' B' C' :PO,
+trianglesSD A B C A' B' C' -> trianglesSD  C A B C' A' B' .
+auto with geo.
+Qed.
+
+Lemma trianglesSD_ordre_permute2 :
+forall A B C A' B' C' :PO,
+trianglesSD A B C A' B' C' -> trianglesSD  B A C B' A' C' .
+auto with geo.
+Qed.
+
+Lemma trianglesSD_ordre_permute3 :
+forall A B C A' B' C' :PO,
+trianglesSD A B C A' B' C' -> trianglesSD  C B A C' B' A'.
+auto with geo.
+Qed.
+
+Lemma trianglesSI_ordre_cycle2 :
+forall A B C A' B' C' :PO,
+trianglesSI A B C A' B' C' -> trianglesSI  C A B C' A' B' .
+auto with geo.
+Qed.
+
+Lemma trianglesSI_ordre_permute2 :
+forall A B C A' B' C' :PO,
+trianglesSI A B C A' B' C' -> trianglesSI  B A C B' A' C' .
+auto with geo.
+Qed.
+
+Lemma trianglesSI_ordre_permute3 :
+forall A B C A' B' C' :PO,
+trianglesSI A B C A' B' C' -> trianglesSI  C B A C' B' A'.
+auto with geo.
+Qed.
+
+Lemma trianglesS_trans_DD:
+forall A B C A' B' C' M N P :PO,
+trianglesSD A B C A' B' C' -> trianglesSD  A' B' C' M N P ->
+trianglesSD A B C M N P.
+intros A B C A' B' C' M N P H H1.
+expand_triangles_semblables ;clear H1 .
+expand_triangles_semblables ;clear H .
+rewrite ->H3 in H15.
+rewrite ->H6 in H18.
+unfold trianglesSD; auto.
+Qed.
+
+Lemma trianglesS_trans_DI:
+forall A B C A' B' C' M N P :PO,
+trianglesSD A B C A' B' C' -> trianglesSI  A' B' C' M N P->
+trianglesSI A B C M N P.
+intros A B C A' B' C' M N P H H1.
+expand_triangles_semblables ;clear H .
+expand_triangles_semblables ;clear H1 .
+rewrite <-H3 in H15.
+rewrite <-H6 in H18.
+unfold trianglesSI; auto.
+Qed.
+
+Lemma trianglesS_trans_II:
+forall A B C A' B' C' M N P :PO,
+trianglesSI A B C A' B' C' -> trianglesSI  A' B' C' M N P->
+trianglesSD A B C M N P.
+intros A B C A' B' C' M N P H H1.
+expand_triangles_semblables ;clear H1 .
+expand_triangles_semblables ;clear H .
+assert (H31: cons_AV (vec B' A') (vec B' C') = cons_AV (vec N P)(vec N M))
+by (apply permute_angles ;auto).
+assert (H32: cons_AV (vec C' B') (vec C' A') = cons_AV (vec P M)(vec P N))
+by (apply permute_angles ;auto).
+rewrite H31 in H15.
+rewrite H32 in H18.
+unfold trianglesSD; auto.
+Qed.
+
+
+(* Lemmes related to similarity between a triangle and its transformations *)
+
+Lemma alignes_imageZeroPi:
+forall A B C : PO,
+A<>B->A<>C->
+alignes A B C ->
+(cons_AV(vec A B)(vec A C) = image_angle 0)
+  \/(cons_AV(vec A B)(vec A C) = image_angle pi).
+intros A B C H H0 H1.
+halignes H1 k.
+elim (Rtotal_order k 0);intros.
+right.
+rewrite ->(@angle_produit_negatif_r k A B C A B);auto.
+rewrite <-angle_nul;auto .
+rewrite plus_commutative with (a :=image_angle 0)(b:=image_angle pi);auto with geo.
+elim H3;intro H4.
+rewrite H4 in H2.
+rewrite (@produit_zero_conf k A C A B) in H0;auto.
+elim H0;auto.
+rewrite H4;assumption.
+left.
+rewrite (@angle_produit_positif_r k A B C A B );auto.
+rewrite <-angle_nul;auto .
+Qed.
+
+
+Lemma rotation_image_bipoint_coincide :
+forall (I A B A' B' :PO) ( a : R),
+A' = rotation I a A ->
+B' = rotation I a B ->
+A =B -> A' = B'.
+intros I A B A' B' a H H0 H1.
+rewrite ->H1 in H.
+rewrite <-H0 in H.
+assumption.
+Qed.
+
+
+Lemma rotation_conserve_alignement:
+forall (I A B C A' B' C' :PO) ( a : R),
+A' = rotation I a A ->
+B' = rotation I a B ->
+C' = rotation I a C ->
+alignes A B C -> alignes A' B' C'.
+intros I A B C A' B' C' a H H0 H1 H2 .
+discrimine A B .
+elim (@rotation_image_bipoint_coincide I A B A' B' a);auto with geo.
+discrimine B C .
+elim (@rotation_image_bipoint_coincide I B C B' C' a);auto with geo.
+discrimine C A .
+elim (@rotation_image_bipoint_coincide I C A C' A' a);auto with geo.
+assert (cons_AV (vec A B) (vec A C) = cons_AV (vec A' B') (vec A' C')).
+apply (@rotation_conserve_angle I A B C A' B' C' a);auto.
+elim(@ alignes_imageZeroPi A B C);intros;auto.
+rewrite H7 in H6.
+elim (@angle_nul_positif_colineaire A' B' C').
+intros.
+elim H8;intros.
+apply colineaire_alignes with x;auto.
+apply image_bipoint_distinct with (I:=I)(a:=a) (A:=A)(B:=B);auto.
+apply image_bipoint_distinct with (I:=I)(a:=a) (A:=A)(B:=C);auto.
+auto.
+elim angle_pi_negatif_colineaire with (A:=A')(B:=B')(C:=C').
+intros.
+elim H8;intros.
+apply colineaire_alignes with x;auto.
+apply image_bipoint_distinct with (I:=I)(a:=a) (A:=A)(B:=B);auto.
+apply image_bipoint_distinct with (I:=I)(a:=a) (A:=A)(B:=C);auto.
+rewrite <-H6;assumption.
+Qed.
+
+(* Lemme related to similarity between a triangle and its Rotation *)
+Lemma triangle_rotation_trianglesSD:
+forall (I A B C A' B' C' :PO) ( a : R),
+triangle A B C ->
+A' = rotation I a A ->
+B' = rotation I a B ->
+C' = rotation I a C ->
+trianglesSD A B C A' B' C'.
+intros I A B C A' B' C' a H H1 H2.
+deroule_triangle A B C.
+unfold trianglesSD.
+repeat split;[assumption|idtac|
+            apply rotation_conserve_angle with (I:=I)( a:=a);auto with geo|
+            apply rotation_conserve_angle with (I:=I)( a:=a);auto with geo].
+intro.
+elim H0.
+apply (@rotation_conserve_alignement I A' B' C' A B C (-a) );
+[apply rotation_inverse ;auto with geo|
+apply rotation_inverse;auto with geo|
+apply rotation_inverse;auto with geo|idtac].
+assumption.
+Qed.
+
+
+Lemma reflexion_image_bipoint_coincide :
+forall (M N A B A' B' :PO),
+M<>N->
+A' = reflexion M N A ->
+B' = reflexion M N B ->
+A =B -> A' = B'.
+intros M N A B A' B' H H0 H1 H2.
+rewrite ->H2 in H0.
+rewrite <-H1 in H0.
+assumption.
+Qed.
+Lemma reflexion_image_bipoint_distinct :
+forall (M N A B A' B' :PO),
+M<>N->
+A' = reflexion M N A ->
+B' = reflexion M N B ->
+A <>B -> A'<> B'.
+intros.
+generalize (@reflexion_isometrie M N A A' B B');
+ intros H7.
+apply (isometrie_distinct (A:=A) (B:=B)); auto.
+Qed.
+
+Lemma reflexion_conserve_alignement:
+forall (M N A B C A' B' C' :PO) ,
+M<>N->
+A' = reflexion M N A ->
+B' = reflexion M N B ->
+C' = reflexion M N C ->
+alignes A B C -> alignes A' B' C'.
+intros M N A B C A' B' C' H0 H1 H2 H3 H.
+discrimine A B .
+elim (@reflexion_image_bipoint_coincide M N A B A' B' );auto with geo.
+discrimine B C .
+elim (@reflexion_image_bipoint_coincide M N B C B' C' );auto with geo.
+discrimine C A .
+elim (@reflexion_image_bipoint_coincide M N C A C' A' );auto with geo.
+assert (cons_AV (vec A' B') (vec A' C') = opp(cons_AV (vec A B) (vec A C))).
+apply (@reflexion_anti_deplacement M N A A' B B' C C' );auto.
+elim(@ alignes_imageZeroPi A B C);intros;auto.
+rewrite H8 in H7.
+assert (image_angle (- 0) = opp (image_angle 0)).
+apply (@mes_opp 0);auto.
+replace (-0) with (0) in H9.
+rewrite <-H9 in H7.
+elim (@angle_nul_positif_colineaire A' B' C').
+intros.
+elim H10;intros.
+apply colineaire_alignes with x;auto.
+apply reflexion_image_bipoint_distinct with (M:=M)(N:=N) (A:=A)(B:=B);auto.
+apply reflexion_image_bipoint_distinct with (M:=M)(N:=N) (A:=A)(B:=C);auto.
+assumption.
+field.
+
+rewrite H8 in H7.
+assert (image_angle (pi) = opp(image_angle (pi ))).
+rewrite <-mes_opp.
+rewrite <-plus_angle_zero.
+rewrite <-pi_plus_pi.
+rewrite <-add_mes_compatible.
+unfold deuxpi.
+replace (-pi +(pi +pi)) with (pi).
+trivial.
+field.
+rewrite <-H9 in H7.
+elim angle_pi_negatif_colineaire with (A:=A')(B:=B')(C:=C').
+intros.
+elim H10;intros.
+apply colineaire_alignes with x;auto.
+apply reflexion_image_bipoint_distinct with (M:=M)(N:=N) (A:=A)(B:=B);auto.
+apply reflexion_image_bipoint_distinct with (M:=M)(N:=N) (A:=A)(B:=C);auto.
+assumption.
+Qed.
+
+(* Lemme related to similarity between a triangle and its Reflexion *)
+Lemma triangle_reflexion_trianglesSI:
+forall (M N A B C A' B' C' :PO) ,
+M<>N->
+triangle A B C ->
+A' = reflexion M N A ->
+B' = reflexion M N B ->
+C' = reflexion M N C ->
+trianglesSI A B C A' B' C'.
+
+intros M N A B C A' B' C' H H0 H1 H2 H3.
+deroule_triangle A B C.
+unfold trianglesSI.
+repeat split;[assumption|idtac|
+            rewrite-> (@reflexion_anti_deplacement M N B B' A A' C C');auto with geo;rewrite->def_opp ; auto|
+            rewrite-> (@reflexion_anti_deplacement M N C C' B B' A A' );auto with geo;rewrite->def_opp ; auto].
+intro.
+elim H4.
+apply (@reflexion_conserve_alignement M N A' B' C' A B C );
+[assumption|apply reflexion_symetrie ;auto with geo|
+apply reflexion_symetrie;auto with geo|
+apply reflexion_symetrie;auto with geo|idtac].
+assumption.
+Qed.
+
+(* Lemme related to similarity between a triangle and its Transition *)
+Lemma triangle_translation_trianglesSD:
+forall I J A A' B B' C C' : PO,
+triangle A B C ->
+A' = translation I J A->
+B' = translation I J B->
+C' = translation I J C ->
+trianglesSD A B C A' B' C'.
+intros I J A A' B B' C C' H0 H1 H2 H3.
+unfold trianglesSD.
+repeat split;[assumption|idtac|
+            (rewrite (@translation_bipoint I J B B' C C');auto);
+(rewrite (@translation_bipoint I J B B' A A');auto)|
+            (rewrite (@translation_bipoint I J C C' A A');auto);
+(rewrite (@translation_bipoint I J C C' B B');auto)
+           ].
+unfold triangle in *.
+intro H4.
+elim H0.
+halignes H4 k.
+assert (A=B).
+apply distance_refl1.
+rewrite <-(@ translation_isometrie I J A A' B B');auto.
+apply distance_refl2;assumption.
+rewrite H;auto with geo.
+apply colineaire_alignes with (k:=k);auto.
+rewrite (@translation_bipoint I J A A' B B');auto.
+rewrite (@translation_bipoint I J A A' C C');auto.
+Qed.
+
+Lemma inversion_colineaire :
+ forall (k : R) (A B C : PO),
+ A <> C -> vec A C = mult_PP k (vec A B) -> vec A B = mult_PP (/ k) (vec A C).
+intros.
+cut (k <> 0); intros.
+rewrite H0.
+Fieldvec k.
+contrapose H.
+apply vecteur_nul_conf.
+rewrite H0; rewrite H1; Ringvec.
+Qed.
+
+(* Lemma related to equality of angles between corresponding sides of 2 similar triangles *)
+Lemma trianglesSD_angles_cotes :
+forall A B C M N P :PO,
+trianglesSD A B C M N P->
+exists x:R,
+	cons_AV (vec M N)(vec A B) =image_angle x /\
+	cons_AV (vec N P)(vec B C) =image_angle x /\
+	cons_AV (vec P M)(vec C A) =image_angle x.
+intros A B C M N P H.
+expand_triangles_semblables.
+elim (tout_angle_a_une_mesure (A:=N) (B:=P) (C:=B) (D:=C)); auto with geo.
+intros x H13.
+exists x;repeat split;auto.
+rewrite <-(@Chasles M N P N A B);auto.
+rewrite <-(@Chasles P N C B A B);auto.
+rewrite (@plus_commutative
+          (cons_AV (vec  P N)(vec C B)) (cons_AV(vec C B)(vec A B))).
+rewrite plus_associative.
+rewrite (@angle_oppu_oppv  B C B A);auto.
+rewrite H2.
+rewrite <-(@angle_oppu_oppv  N P N M);auto.
+rewrite Chasles;auto.
+rewrite (@angle_oppu_oppv  N P B C);auto.
+rewrite <-H13.
+rewrite <-angle_nul;auto.
+rewrite plus_commutative.
+rewrite plus_angle_zero;auto.
+
+rewrite <-(@Chasles P M  P N C A  );auto.
+rewrite <-(@Chasles P N C B C A);auto.
+rewrite (@plus_commutative
+          (cons_AV (vec  P N)(vec C B)) (cons_AV(vec C B)(vec C A))).
+rewrite plus_associative.
+rewrite <-H5.
+rewrite Chasles;auto.
+rewrite (@angle_oppu_oppv  N P B C);auto.
+rewrite <-H13.
+rewrite <-angle_nul;auto.
+rewrite plus_commutative.
+rewrite plus_angle_zero;auto.
+Qed.
+
+
+Lemma Thales_consequence :
+forall A B C M N :PO,
+triangle A B C -> triangle A M N -> alignes A M B -> alignes A N C ->
+paralleles (droite M N) (droite B C)->
+    exists k:R,
+                     distance B C = k* distance M N  /\
+                     distance A B = k* distance A M /\
+                     distance A C = k * distance A N /\ k<>0.
+intros A B C M N H0 H1 H2 H3 H.
+deroule_triangle A B C.
+deroule_triangle A M N.
+halignes H2 k.
+assert (vec A M = mult_PP (/k) (vec A B)).
+apply (@inversion_colineaire k A M B H7 H12).
+assert (k<>0).
+red;intros.
+rewrite H14 in H12.
+unfold vec at 2 in H12 .
+assert(mult_PP 0 (add_PP(cons(-1) A)(cons 1 M) ) = zero) by RingPP.
+rewrite H15 in H12.
+assert (A=B) by apply (@vecteur_nul_conf A B H12) .
+elim H7;auto.
+assert (/k<>0) by apply (@Rinv_neq_0_compat k H14).
+assert (vec A N = mult_PP (/k) (vec A C)) by
+      (apply (@Thales_concours (/k) A B C M N H0 H15 H13);auto with geo).
+assert (vec A C = mult_PP (k) (vec A N)) .
+elim (@Rinv_involutive k);auto.
+apply (@inversion_colineaire (/k) A C N );auto.
+assert (vec B C =mult_PP (k) (vec M N)).
+rewrite <-(@Chasles_vec M A N).
+rewrite <- distrib_mult_PP .
+rewrite <-H17 .
+assert ( vec B A = mult_PP (k) (vec M A)).
+rewrite(@opp_vecteur A M ).
+rewrite mult_mult_vec .
+replace (k * -1) with (-1 * k).
+rewrite <-mult_mult_vec .
+rewrite <-H12.
+apply opp_vecteur;auto.
+ring.
+rewrite <-H18.
+rewrite  Chasles_vec;auto.
+exists (Rabs(k)).
+repeat split;
+[apply colinearite_distance;auto |apply colinearite_distance;auto|
+apply colinearite_distance;auto|apply Rabs_no_R0;auto].
+
+Qed.
+
+
+Lemma  imageZeroPi_paralelles:
+forall A B C D: PO,
+A<>B->C<>D->
+(cons_AV(vec A B)(vec C D) = image_angle 0)
+  \/(cons_AV(vec A B)(vec C D) = image_angle pi) ->
+paralleles (droite A B) (droite C D).
+intros A B C D H H1 H2.
+set (B' := translation A C B).
+assert (H3:= refl_equal B'); unfold B' at 2 in H3.
+assert (H4 : C =translation A C A) by (apply translation_trivial;auto).
+assert (H5 :vec A B =vec C B') by (apply  (@translation_bipoint A C);auto).
+rewrite H5 in H2.
+assert (H6:C <>B').
+red;intro H7.
+rewrite H7 in H5.
+rewrite <-(@mult_1_vec B' B') in H5.
+rewrite <-vecteur_nul in H5.
+assert (A = B) by (apply vecteur_nul_conf;auto).
+elim H;auto.
+apply (@paralleles_trans A B C B' C D);auto.
+rewrite <-(@mult_1_vec C B') in H5.
+apply (colineaires_paralleles (k:=1) );auto .
+elim H2;intro H7.
+elim (@angle_nul_positif_colineaire C B' D);auto.
+intros x [H8 H9].
+assert (paralleles (droite C D)(droite C B')) by (apply colineaires_paralleles with (k:=x);auto).
+apply  paralleles_sym;assumption.
+elim (@angle_pi_negatif_colineaire C B' D);auto.
+intros x [H8 H9].
+assert (paralleles (droite C D)(droite C B')) by (apply colineaires_paralleles with (k:=x);auto).
+apply  paralleles_sym;assumption.
+Qed.
+
+(* Lemme related to proportionate sides of 2 direct similar triangles  *)
+Lemma trianglesSD_proportion :
+forall A B C A' B' C' :PO,
+trianglesSD A B C A' B' C' ->
+    exists k:R,
+                      distance B C =k*distance B' C' /\
+                      distance A B = k*distance A' B' /\
+                      distance A C = k * distance A' C'/\ k<>0.
+
+intros A B C A' B' C' H.
+generalize H;intro H1.
+destruct H1 as [H2 [H3 [H4 H5]]].
+elim (@tout_angle_a_une_mesure A' B' A B);
+  [intros |deroule_triangle A' B' C';auto|deroule_triangle A B C;auto].
+set (M:=(rotation A' x B')).
+assert (H6 := refl_equal M); unfold M at 2 in H6.
+set (N:=(rotation A' x C')).
+assert (H7 := refl_equal N); unfold N at 2 in H7.
+assert (H8 : A' = rotation A' x A') by
+   (apply rotation_def_centre;auto).
+assert ( H9: trianglesSD A' B' C' A' M N)
+   by ( apply triangle_rotation_trianglesSD  with (I := A') (a:=x);auto).
+set (B'':=(translation A' A M)).
+assert (H10 := refl_equal B''); unfold B'' at 2 in H10.
+set (C'':=(translation A' A N)).
+assert (H11:= refl_equal C''); unfold C'' at 2 in H11.
+assert (H12 : A = translation A' A A') by
+   (apply rec_translation_vecteur;auto).
+assert ( H13: trianglesSD A' M N A B'' C'').
+apply (@triangle_translation_trianglesSD  A' A);auto.
+destruct H9 as [H' [H'' _]];intros;auto.
+assert (H14 :trianglesSD A B C A B'' C'' ).
+apply (@trianglesS_trans_DD A B C A' M N A B'' C'');auto.
+apply (@trianglesS_trans_DD A B C A' B' C' A' M N);auto.
+assert (H15 : distance B' C' = distance B'' C'').
+rewrite <-(@rotation_isometrie A' B' C' M N x);auto.
+rewrite <-(@translation_isometrie A' A M B'' N C'');auto.
+assert (H16 :distance A' B' = distance A B'').
+rewrite <-(@rotation_isometrie A' A' B' A' M x);auto.
+rewrite <-(@translation_isometrie A' A A' A M B'');auto.
+assert (H17:distance A' C' = distance A C'').
+rewrite <-(@rotation_isometrie A' A' C' A' N x);auto.
+rewrite <-(@translation_isometrie A' A A' A N C'');auto.
+rewrite H15;rewrite H16;rewrite H17.
+generalize H14;intros H80.
+destruct H80 as [H' [H'' _]];intros;auto.
+deroule_triangle A B C.
+deroule_triangle A' B' C'.
+deroule_triangle A B'' C''.
+assert (cons_AV  (vec A' B') (vec A B'') = image_angle x).
+rewrite  <-(@translation_bipoint A' A A' A M B'');auto.
+elim (@rotation_def A' B' M x);auto with geo.
+rewrite H0 in H27.
+assert (cons_AV (vec A B'') (vec A B) =image_angle 0).
+rewrite <-(@Chasles_diff A' B');auto.
+rewrite H27.
+rewrite def_opp;auto.
+rewrite Chasles;auto.
+rewrite <- (@angle_nul);auto.
+elim  (@trianglesSD_angles_cotes A B C A B'' C'');auto;intros .
+destruct H29 as [H81 [H82 H83]].
+rewrite H81 in H28.
+rewrite H28 in H81.
+rewrite H28 in H82.
+rewrite H28 in H83.
+cut (alignes A B'' B);intros.
+cut (alignes A C'' C); intros .
+apply Thales_consequence;auto.
+apply imageZeroPi_paralelles;auto.
+assert (H84 :cons_AV(vec A C'') (vec A C) = cons_AV (vec C'' A)(vec C A)) by
+(apply angle_oppu_oppv;auto).
+rewrite H83 in H84.
+elim (@angle_nul_positif_colineaire A C'' C);[ intros  k [_ H85]|auto|auto|auto].
+unfold alignes;right.
+apply colineaire_alignes1 with (k:=k);auto.
+elim (@angle_nul_positif_colineaire A B'' B);[ intros  k [_ H86]|auto|auto|auto].
+unfold alignes;right.
+apply colineaire_alignes1 with (k:=k);auto.
+Qed.
+
+(* Lemme related to proportionate sides of 2 indirect similar triangles  *)
+Lemma trianglesSI_proportion :
+forall A B C A' B' C' :PO,
+trianglesSI A B C A' B' C' ->
+    exists k:R,
+                      distance B C =k*distance B' C' /\
+                      distance A B = k*distance A' B' /\
+                      distance A C = k * distance A' C' /\ k<>0.
+intros A B C A' B' C' H.
+expand_triangles_semblables.
+set (A'':=(reflexion B' C' A')).
+assert (H20 := refl_equal A''); unfold A'' at 2 in H20.
+assert (H21: B' = reflexion B' C' B') by (apply reflexion_axe;auto with geo).
+assert (H22: C' = reflexion B' C' C') by (apply reflexion_axe;auto with geo).
+assert (H23: trianglesSI A' B' C' A'' B' C')
+by (apply (@triangle_reflexion_trianglesSI B' C');auto).
+assert (H24 : distance A' B' = distance A'' B')
+ by (apply (@reflexion_isometrie B' C');auto).
+assert (H25 : distance A' C' = distance A'' C')
+ by (apply (@reflexion_isometrie B' C');auto).
+rewrite H24.
+rewrite H25.
+assert (H26: trianglesSD A B C A'' B' C')
+by (apply (@trianglesS_trans_II A B C A' B' C' A'' B' C');auto).
+apply trianglesSD_proportion;auto.
+Qed.
+
+(* Lemme related to proportionate sides of 2 similar triangles  *)
+Lemma triangles_semblables_proportion :
+forall A B C A' B' C' :PO,
+triangles_semblables A B C A' B' C' ->
+    exists k:R,
+                      distance B C =k*distance B' C' /\
+                      distance A B = k*distance A' B' /\
+                      distance A C = k * distance A' C' /\ k<>0.
+intros A B C A' B' C' H.
+unfold triangles_semblables in H.
+elim H;intros H1.
+apply trianglesSD_proportion ;auto.
+apply trianglesSI_proportion ;auto.
+Qed.

--- a/trigo.v
+++ b/trigo.v
@@ -18,7 +18,7 @@ Require Export angles_vecteurs.
 Set Implicit Arguments.
 Unset Strict Implicit.
 (* Le plan est orienté et on utilise le cercle trigonométrique*)
- 
+
 Definition repere_orthonormal_direct (O I J : PO) :=
   image_angle pisurdeux = cons_AV (vec O I) (vec O J) /\
   scalaire (vec O I) (vec O I) = 1 /\ scalaire (vec O J) (vec O J) = 1.
@@ -28,7 +28,7 @@ Parameter Cos : AV -> R.
 Parameter Sin : AV -> R.
 (* cosinus et sinus d'un angle (ou d'un réel) sont obtenus par projections
    du point image du cercle trigonométrique sur les axes de coordonnées*)
- 
+
 Axiom
   def_cos :
     forall (A B C : PO) (x : R),
@@ -36,7 +36,7 @@ Axiom
     distance A C = 1 ->
     image_angle x = cons_AV (vec A B) (vec A C) ->
     cos x = scalaire (vec A B) (vec A C).
- 
+
 Axiom
   def_sin :
     forall (A B C D : PO) (x : R),
@@ -44,14 +44,14 @@ Axiom
     distance A C = 1 ->
     image_angle x = cons_AV (vec A B) (vec A C) ->
     repere_orthonormal_direct A B D -> sin x = scalaire (vec A C) (vec A D).
- 
+
 Axiom
   def_Cos :
     forall A B C : PO,
     distance A B = 1 ->
     distance A C = 1 ->
     Cos (cons_AV (vec A B) (vec A C)) = scalaire (vec A B) (vec A C).
- 
+
 Axiom
   def_Sin :
     forall A B C D : PO,
@@ -59,7 +59,7 @@ Axiom
     distance A C = 1 ->
     repere_orthonormal_direct A B D ->
     Sin (cons_AV (vec A B) (vec A C)) = scalaire (vec A C) (vec A D).
- 
+
 Lemma ROND_RON :
  forall O I J : PO,
  repere_orthonormal_direct O I J -> repere_orthonormal O I J.
@@ -68,11 +68,11 @@ elim H; intros H0 H1; try clear H; try exact H1.
 split; [ auto with geo | try assumption ].
 Qed.
 Hint Resolve ROND_RON: geo.
- 
+
 Definition repere_orthonormal_indirect (O I J : PO) :=
   image_angle pisurdeux = cons_AV (vec O J) (vec O I) /\
   scalaire (vec O I) (vec O I) = 1 /\ scalaire (vec O J) (vec O J) = 1.
- 
+
 Lemma ROND_RONI :
  forall O I J : PO,
  repere_orthonormal_direct O I J -> repere_orthonormal_indirect O J I.
@@ -82,7 +82,7 @@ elim H; intros H0 H1; try clear H; try exact H1.
 elim H1; intros H H2; try clear H1; try exact H2.
 split; [ auto | split; [ auto | try assumption ] ].
 Qed.
- 
+
 Lemma ROND_new :
  forall O I J K : PO,
  repere_orthonormal_direct O I J ->
@@ -106,7 +106,7 @@ unfold pi in |- *; ring.
 rewrite H0.
 Simplscal; rewrite H3; ring.
 Qed.
- 
+
 Lemma existence_ROND_AB :
  forall A B : PO,
  distance A B = 1 -> exists C : PO, repere_orthonormal_direct A B C.
@@ -119,7 +119,7 @@ exists C; unfold repere_orthonormal_direct in |- *.
 split; [ try assumption | idtac ].
 split; auto with geo.
 Qed.
- 
+
 Lemma cos_deux_mes :
  forall x y : R, image_angle x = image_angle y -> cos x = cos y.
 intros.
@@ -130,7 +130,7 @@ rewrite (def_cos (A:=A) (B:=B) (C:=C) (x:=x)); auto.
 rewrite (def_cos (A:=A) (B:=B) (C:=C) (x:=y)); auto.
 rewrite <- H3; auto.
 Qed.
- 
+
 Lemma cos_paire : forall x : R, cos (- x) = cos x.
 intros.
 elim existence_AB_unitaire; intros A H; elim H; intros B H0; try clear H;
@@ -143,7 +143,7 @@ rewrite (def_cos (A:=A) (B:=C) (C:=B) (x:=- x)); auto.
 rewrite scalaire_sym; auto.
 apply mes_oppx; auto with geo.
 Qed.
- 
+
 Lemma cos_periodique : forall x : R, cos (x + deuxpi) = cos x.
 intros.
 elim existence_AB_unitaire; intros A H; elim H; intros B H0; try clear H;
@@ -155,7 +155,7 @@ cut (image_angle (x + deuxpi) = cons_AV (vec A B) (vec A C)); intros.
 rewrite (def_cos (A:=A) (B:=B) (C:=C) (x:=x + deuxpi)); auto.
 apply mesure_mod_deuxpi; auto with geo.
 Qed.
- 
+
 Lemma sin_deux_mes :
  forall x y : R, image_angle x = image_angle y -> sin x = sin y.
 intros.
@@ -167,7 +167,7 @@ rewrite (def_sin (A:=A) (B:=B) (C:=C) (D:=D) (x:=x)); auto.
 rewrite (def_sin (A:=A) (B:=B) (C:=C) (D:=D) (x:=y)); auto.
 rewrite <- H3; auto.
 Qed.
- 
+
 Lemma sin_periodique : forall x : R, sin (x + deuxpi) = sin x.
 intros.
 elim existence_AB_unitaire; intros A H; elim H; intros B H0; try clear H;
@@ -180,7 +180,7 @@ cut (image_angle (x + deuxpi) = cons_AV (vec A B) (vec A C)); intros.
 rewrite (def_sin (A:=A) (B:=B) (C:=C) (D:=D) (x:=x + deuxpi)); auto.
 apply mesure_mod_deuxpi; auto with geo.
 Qed.
- 
+
 Lemma sin_cos_pisurdeux_moins_x : forall x : R, sin x = cos (pisurdeux + - x).
 intros.
 elim existence_AB_unitaire; intros A H; elim H; intros B H0; try clear H;
@@ -199,20 +199,20 @@ rewrite add_mes_compatible.
 rewrite H3; rewrite H4; rewrite Chasles; auto with geo.
 apply mes_oppx; auto with geo.
 Qed.
- 
+
 Lemma cos_sin_pisurdeux_moins_x : forall x : R, cos x = sin (pisurdeux + - x).
 intros.
 rewrite sin_cos_pisurdeux_moins_x.
 replace (pisurdeux + - (pisurdeux + - x)) with x; try ring.
 Qed.
- 
+
 Lemma cos_zero : cos 0 = 1.
 elim existence_AB_unitaire; intros A H; elim H; intros B H0; try clear H;
  try exact H0.
 rewrite (def_cos (A:=A) (B:=B) (C:=B) (x:=0)); auto with geo.
 rewrite <- angle_nul; auto with geo.
 Qed.
- 
+
 Lemma sin_zero : sin 0 = 0.
 elim existence_AB_unitaire; intros A H; elim H; intros B H0; try clear H;
  try exact H0.
@@ -221,7 +221,7 @@ elim H; intros.
 rewrite (def_sin (A:=A) (B:=B) (C:=B) (D:=D) (x:=0)); auto with geo.
 rewrite <- angle_nul; auto with geo.
 Qed.
- 
+
 Lemma cos_pisurdeux : cos pisurdeux = 0.
 elim existence_AB_unitaire; intros A H; elim H; intros B H0; try clear H;
  try exact H0.
@@ -230,7 +230,7 @@ elim H; intros.
 elim H2; intros H3 H4; try clear H2; try exact H4.
 rewrite (def_cos (A:=A) (B:=B) (C:=D) (x:=pisurdeux)); auto with geo.
 Qed.
- 
+
 Lemma sin_pisurdeux : sin pisurdeux = 1.
 elim existence_AB_unitaire; intros A H; elim H; intros B H0; try clear H;
  try exact H0.
@@ -239,7 +239,7 @@ elim H; intros.
 elim H2; intros H3 H4; try clear H2; try exact H4.
 rewrite (def_sin (A:=A) (B:=B) (C:=D) (D:=D) (x:=pisurdeux)); auto with geo.
 Qed.
- 
+
 Lemma cos_pi : cos pi = -1.
 elim existence_AB_unitaire; intros A H; elim H; intros B H0; try clear H;
  try exact H0.
@@ -257,7 +257,7 @@ Ringvec.
 rewrite H1.
 Simplscal; rewrite carre_scalaire_distance; rewrite H0; ring.
 Qed.
- 
+
 Lemma sin_pi : sin pi = 0.
 elim existence_AB_unitaire; intros A H; elim H; intros B H0; try clear H;
  try exact H0.
@@ -279,7 +279,7 @@ rewrite <- angle_plat; auto with geo.
 rewrite H3.
 Ringvec.
 Qed.
- 
+
 Lemma coordonnees_cos_sin :
  forall (x : R) (O I J M : PO),
  repere_orthonormal_direct O I J ->
@@ -296,7 +296,7 @@ pattern (vec O M) at 1 in |- *.
 rewrite (coordonnees_scalaire_base (O:=O) (I:=I) (J:=J) M); auto with geo.
 rewrite scalaire_sym; auto.
 Qed.
- 
+
 Lemma calcul_cos_sin :
  forall (x a b : R) (O I J M : PO),
  repere_orthonormal_direct O I J ->
@@ -308,7 +308,7 @@ intros.
 apply unicite_coordonnees with (2 := H2); auto with geo.
 apply coordonnees_cos_sin; auto.
 Qed.
- 
+
 Lemma trigo_Pythagore : forall x : R, Rsqr (cos x) + Rsqr (sin x) = 1.
 unfold Rsqr in |- *; intros.
 elim existence_AB_unitaire; intros A H; elim H; intros B H0; try clear H;
@@ -331,7 +331,7 @@ rewrite (pisurdeux_scalaire_nul (A:=A) (B:=B) (C:=D)); auto.
 ring.
 apply coordonnees_cos_sin; auto.
 Qed.
- 
+
 Lemma pisurdeux_plus_x :
  forall x : R, cos (pisurdeux + x) = - sin x /\ sin (pisurdeux + x) = cos x.
 intros.
@@ -349,7 +349,7 @@ elim
   with (A := A) (B := A) (C := B) (k := -1); intros E H4.
 cut (image_angle x = cons_AV (vec A D) (vec A C)); intros.
 generalize
- (coordonnees_cos_sin (x:=pisurdeux + x) (O:=A) (I:=B) (J:=D) (M:=C)); 
+ (coordonnees_cos_sin (x:=pisurdeux + x) (O:=A) (I:=B) (J:=D) (M:=C));
  intros.
 generalize (coordonnees_cos_sin (x:=x) (O:=A) (I:=D) (J:=E) (M:=C)); intros.
 cut
@@ -369,7 +369,7 @@ apply add_mes_compatible.
 apply mes_oppx; auto with geo.
 apply Chasles; auto with geo.
 Qed.
- 
+
 Lemma sin_impaire : forall x : R, sin (- x) = - sin x.
 intros.
 elim pisurdeux_plus_x with (x := - x); intros H H0;
@@ -382,7 +382,7 @@ ring.
 ring.
 ring.
 Qed.
- 
+
 Lemma pi_moins_x :
  forall x : R, cos (pi + - x) = - cos x /\ sin (pi + - x) = sin x.
 intros.
@@ -396,7 +396,7 @@ rewrite cos_sin_pisurdeux_moins_x; auto.
 rewrite sin_cos_pisurdeux_moins_x; auto.
 ring.
 Qed.
- 
+
 Lemma pi_plus_x :
  forall x : R, cos (pi + x) = - cos x /\ sin (pi + x) = - sin x.
 intros.
@@ -409,7 +409,7 @@ rewrite cos_paire; auto.
 rewrite sin_impaire; auto.
 ring.
 Qed.
- 
+
 Theorem cos_diff :
  forall a b : R, cos (a + - b) = cos a * cos b + sin a * sin b.
 intros.
@@ -445,7 +445,7 @@ rewrite H9; rewrite H8; rewrite H7.
 rewrite scalaire_sym; rewrite H7.
 ring.
 Qed.
- 
+
 Lemma cos_som :
  forall a b : R, cos (a + b) = cos a * cos b + - (sin a * sin b).
 intros.
@@ -456,7 +456,7 @@ rewrite sin_impaire.
 ring.
 ring.
 Qed.
- 
+
 Lemma sin_som : forall a b : R, sin (a + b) = sin a * cos b + sin b * cos a.
 intros.
 replace (sin (a + b)) with (cos (pisurdeux + - (a + b))).
@@ -468,7 +468,7 @@ ring.
 ring.
 rewrite <- sin_cos_pisurdeux_moins_x; auto.
 Qed.
- 
+
 Lemma sin_diff :
  forall a b : R, sin (a + - b) = sin a * cos b + - (sin b * cos a).
 intros.
@@ -477,7 +477,7 @@ rewrite cos_paire.
 rewrite sin_impaire.
 ring.
 Qed.
- 
+
 Lemma duplication_cos : forall a : R, cos (2 * a) = 2 * Rsqr (cos a) + -1.
 intros.
 repeat rewrite double.
@@ -486,7 +486,7 @@ replace (-1) with (-(1)) by ring.
 rewrite <- (trigo_Pythagore a).
 unfold Rsqr; ring.
 Qed.
- 
+
 Lemma duplication_cos2 : forall a : R, cos (2 * a) = 1 + - (2 * Rsqr (sin a)).
 intros.
 repeat rewrite double.
@@ -494,13 +494,13 @@ rewrite cos_som.
 rewrite <- (trigo_Pythagore a).
 unfold Rsqr; ring.
 Qed.
- 
+
 Lemma duplication_sin : forall a : R, sin (2 * a) = 2 * (sin a * cos a).
 intros.
 repeat rewrite double.
 rewrite sin_som; auto.
 Qed.
- 
+
 Lemma coordonnees_polaires_cartesiennes :
  forall (x y a r : R) (O I J M : PO),
  repere_orthonormal_direct O I J ->
@@ -530,7 +530,7 @@ elim def_representant_unitaire2 with (A := O) (B := M) (C := C);
  | auto
  | auto ].
 Qed.
- 
+
 Lemma trivial_cos_Cos :
  forall (A B C : PO) (x : R),
  distance A B = 1 ->
@@ -541,7 +541,7 @@ intros.
 rewrite (def_cos (A:=A) (B:=B) (C:=C) (x:=x)); auto.
 rewrite (def_Cos (A:=A) (B:=B) (C:=C)); auto.
 Qed.
- 
+
 Lemma egalite_cos_Cos :
  forall (A B C : PO) (x : R),
  A <> B ->
@@ -567,7 +567,7 @@ elim H5; auto with geo.
 rewrite H2; rewrite H3; rewrite H1; rewrite angles_representants_unitaires;
  auto with geo.
 Qed.
- 
+
 Lemma trivial_sin_Sin :
  forall (A B C D : PO) (x : R),
  distance A B = 1 ->
@@ -578,7 +578,7 @@ intros.
 rewrite (def_sin (A:=A) (B:=B) (C:=C) (D:=D) (x:=x)); auto.
 rewrite (def_Sin (A:=A) (B:=B) (C:=C) (D:=D)); auto.
 Qed.
- 
+
 Lemma egalite_sin_Sin :
  forall (A B C : PO) (x : R),
  A <> B ->
@@ -608,7 +608,7 @@ elim def_representant_unitaire2 with (A := A) (B := B) (C := B');
  auto with geo; intros.
 elim H4; auto with geo.
 Qed.
- 
+
 Lemma coordonnees_Cos_Sin :
  forall O I J M : PO,
  repere_orthonormal_direct O I J ->
@@ -626,7 +626,7 @@ rewrite <- (trivial_sin_Sin (A:=O) (B:=I) (C:=M) (D:=J) (x:=x));
 rewrite <- (trivial_cos_Cos (A:=O) (B:=I) (C:=M) (x:=x)); auto with geo.
 apply coordonnees_cos_sin; auto.
 Qed.
- 
+
 Lemma calcul_Cos_Sin :
  forall (a b : R) (O I J M : PO),
  repere_orthonormal_direct O I J ->
@@ -644,9 +644,21 @@ rewrite <- (trivial_sin_Sin (A:=O) (B:=I) (C:=M) (D:=J) (x:=x));
 rewrite <- (trivial_cos_Cos (A:=O) (B:=I) (C:=M) (x:=x)); auto with geo.
 apply (calcul_cos_sin (x:=x) (a:=a) (b:=b) (O:=O) (I:=I) (J:=J) (M:=M)); auto.
 Qed.
- 
+
 Axiom
   egalite_angle_trigo :
     forall x y : R,
     sin x = sin y -> cos x = cos y -> image_angle x = image_angle y.
+
 Hint Resolve egalite_angle_trigo: geo.
+
+Lemma egalite_angle_PiPres_trigo:
+    forall x y :R,
+    sin x = -sin y ->cos x = -cos y -> image_angle x = image_angle (y+pi).
+intros x y H H0.
+destruct (@pi_plus_x y) as [H1 H2].
+rewrite <-H2 in H.
+rewrite <-H1 in H0.
+replace (y+pi) with (pi +y);auto with real.
+apply egalite_angle_trigo;auto.
+Qed.


### PR DESCRIPTION
Tuan Minh Pham published a paper [Similar Triangles and Orientation in Plane Elementary Geometry for Coq-based Proofs](https://hal.inria.fr/inria-00585203) where he claims to have proved Ptolemy's theorem in the context of HighSchoolGeometry.

This commit adds the few files whose addition is needed for the proof to compile.  The statement is different from what appears in the paper, but understandable.